### PR TITLE
Fix issue #8 - aliases in config files

### DIFF
--- a/viper_test.go
+++ b/viper_test.go
@@ -21,7 +21,9 @@ hobbies:
 clothing:
   jacket: leather
   trousers: denim
-age: 35`)
+age: 35
+beard: true
+`)
 
 var tomlExample = []byte(`
 title = "TOML Example"
@@ -85,6 +87,15 @@ func TestAliases(t *testing.T) {
 	assert.Equal(t, 40, Get("years"))
 	Set("years", 45)
 	assert.Equal(t, 45, Get("age"))
+}
+
+func TestAliasInConfigFile(t *testing.T) {
+	// the config file specifies "beard".  If we make this an alias for
+	// "hasbeard", we still want the old config file to work with beard.
+	RegisterAlias("beard", "hasbeard")
+	assert.Equal(t, true, Get("hasbeard"))
+	Set("hasbeard", false)
+	assert.Equal(t, false, Get("beard"))
 }
 
 func TestYML(t *testing.T) {


### PR DESCRIPTION
(note, this includes my other pull request which fixes the tests so they can run)

This fixes issue #8, the aliases in config files bug.  Whenever we register an alias, if there is a value in the config (or defaults or override) for the alias, we move that value to the new "real key".

Added a test for the bug, which fails without the changes and passes with the changes.

This also fixes a bug in Hugo, where specifying "Taxonomies" in your config file doesn't get recognized, because Hugo aliases "Taxonomies" to "Indexes" which means that when the code does a Get("Taxnomies") it got translated to Get("Indexes"), which didn't exist in the original config map.
