### PR TITLE
Included .yml as supported extension.

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -34,7 +34,7 @@ var configPaths []string
 var configName string = "config"
 
 // extensions Supported
-var SupportedExts []string = []string{"json", "toml", "yaml"}
+var SupportedExts []string = []string{"json", "toml", "yaml", "yml"}
 var configFile string
 var configType string
 


### PR DESCRIPTION
Hi. Thanks for creating Viper, it's been very useful to me. I come from Ruby and .yaml is really never used there, .yml is the common extension. I verified online and it's valid known extension for Yaml files so I added it. I realized this when trying to use `config.yml` in a project and getting an error on my code. Does adding this makes sense? Pretty silly addition, but it did confuse me for a while to realize the error using my app on a server, so I think it's worth adding. Cheers.
