### PR TITLE
Fixing problems with casing on keys in BindEnv and BindPFlag

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -147,7 +147,7 @@ func BindPFlag(key string, flag *pflag.Flag) (err error) {
 	if flag == nil {
 		return fmt.Errorf("flag for %q is nil", key)
 	}
-	pflags[key] = flag
+	pflags[strings.ToLower(key)] = flag
 
 	switch flag.Value.Type() {
 	case "int", "int8", "int16", "int32", "int64":
@@ -169,7 +169,7 @@ func BindEnv(input ...string) (err error) {
 		return fmt.Errorf("BindEnv missing key to bind to")
 	}
 
-	key = input[0]
+	key = strings.ToLower(input[0])
 
 	if len(input) == 1 {
 		envkey = strings.ToUpper(key)

--- a/viper_test.go
+++ b/viper_test.go
@@ -27,6 +27,7 @@ clothing:
   jacket: leather
   trousers: denim
 age: 35
+eyes : brown
 beard: true
 `)
 
@@ -170,9 +171,9 @@ func TestEnv(t *testing.T) {
 }
 
 func TestAllKeys(t *testing.T) {
-	ks := sort.StringSlice{"title", "owner", "name", "beard", "ppu", "batters", "hobbies", "clothing", "age", "hacker", "id", "type"}
+	ks := sort.StringSlice{"title", "owner", "name", "beard", "ppu", "batters", "hobbies", "clothing", "age", "hacker", "id", "type", "eyes"}
 	dob, _ := time.Parse(time.RFC3339, "1979-05-27T07:32:00Z")
-	all := map[string]interface{}{"hacker": true, "beard": true, "batters": map[string]interface{}{"batter": []interface{}{map[string]interface{}{"type": "Regular"}, map[string]interface{}{"type": "Chocolate"}, map[string]interface{}{"type": "Blueberry"}, map[string]interface{}{"type": "Devil's Food"}}}, "hobbies": []interface{}{"skateboarding", "snowboarding", "go"}, "ppu": 0.55, "clothing": map[interface{}]interface{}{"jacket": "leather", "trousers": "denim"}, "name": "crunk", "owner": map[string]interface{}{"organization": "MongoDB", "Bio": "MongoDB Chief Developer Advocate & Hacker at Large", "dob": dob}, "id": "13", "title": "TOML Example", "age": 35, "type": "donut"}
+	all := map[string]interface{}{"hacker": true, "beard": true, "batters": map[string]interface{}{"batter": []interface{}{map[string]interface{}{"type": "Regular"}, map[string]interface{}{"type": "Chocolate"}, map[string]interface{}{"type": "Blueberry"}, map[string]interface{}{"type": "Devil's Food"}}}, "hobbies": []interface{}{"skateboarding", "snowboarding", "go"}, "ppu": 0.55, "clothing": map[interface{}]interface{}{"jacket": "leather", "trousers": "denim"}, "name": "crunk", "owner": map[string]interface{}{"organization": "MongoDB", "Bio": "MongoDB Chief Developer Advocate & Hacker at Large", "dob": dob}, "id": "13", "title": "TOML Example", "age": 35, "type": "donut", "eyes": "brown"}
 
 	var allkeys sort.StringSlice
 	allkeys = AllKeys()
@@ -244,5 +245,28 @@ func TestBindPFlag(t *testing.T) {
 	flag.Changed = true //hack for pflag usage
 
 	assert.Equal(t, "testing_mutate", Get("testvalue"))
+
+}
+
+func TestBoundCaseSensitivity(t *testing.T) {
+
+	assert.Equal(t, "brown", Get("eyes"))
+
+	BindEnv("eYEs", "TURTLE_EYES")
+	os.Setenv("TURTLE_EYES", "blue")
+
+	assert.Equal(t, "blue", Get("eyes"))
+
+	var testString = "green"
+	var testValue = newStringValue(testString, &testString)
+
+	flag := &pflag.Flag{
+		Name:    "eyeballs",
+		Value:   testValue,
+		Changed: true,
+	}
+
+	BindPFlag("eYEs", flag)
+	assert.Equal(t, "green", Get("eyes"))
 
 }


### PR DESCRIPTION
Ran into an issue where I was utilizing camelcased names for keys (before I realized everything was ToLower()ed) and saw an bug where the keys inserted into the maps for env and flags wouldn't match the keys I was requesting.

As an aside - something that really perplexes me still - when I use: 

``` go
BindEnv("eYEs")
```

in the test (not the key,ENVKEY way as in the pull request) somehow this test passes without the changes I made lowering the keys being inserted into the 'env' map. In my mental model of how this works from reading the code this should still fail... (but I'm quite a newb here with go)
