### PR TITLE
Attempt to resolve issue 579.

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -39,7 +39,7 @@ import (
 )
 
 // A set of paths to look for the config file in
-var configPaths []string
+var configPaths []string = []string{"."}
 
 // Name of file to look for inside the path
 var configName string = "config"


### PR DESCRIPTION
(Edit: it's issue 579 of hugo project)

Config file is not being picked up when running `hugo server --watch`
from within the hugo project directory (the site).

I know this is intended to solve an issue with hugo (I see it as an issue anyway)... but isn't it a good idea to have  "." in the configPaths?

I am not familiar with either Go, Hugo, or Viper so most likely there is a better solution.

Regards,
Justin