### PR TITLE
update to consistently use filepath instead of path and add looking in o...

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -650,10 +649,10 @@ func searchInPath(in string) (filename string) {
 	jww.DEBUG.Println("Searching for config in ", in)
 	for _, ext := range SupportedExts {
 
-		jww.DEBUG.Println("Checking for", path.Join(in, configName+"."+ext))
-		if b, _ := exists(path.Join(in, configName+"."+ext)); b {
-			jww.DEBUG.Println("Found: ", path.Join(in, configName+"."+ext))
-			return path.Join(in, configName+"."+ext)
+		jww.DEBUG.Println("Checking for", filepath.Join(in, configName+"."+ext))
+		if b, _ := exists(filepath.Join(in, configName+"."+ext)); b {
+			jww.DEBUG.Println("Found: ", filepath.Join(in, configName+"."+ext))
+			return filepath.Join(in, configName+"."+ext)
 		}
 	}
 
@@ -669,13 +668,19 @@ func findConfigFile() (string, error) {
 			return file, nil
 		}
 	}
-	cwd, _ := findCWD()
 
+	cwd, _ := findCWD()
 	file := searchInPath(cwd)
 	if file != "" {
 		return file, nil
 	}
 
+	// try the current working directory
+	wd, _ := os.Getwd()
+	file = searchInPath(wd)
+	if file != "" {
+		return file, nil
+	}
 	return "", fmt.Errorf("config file not found in: %s", configPaths)
 }
 


### PR DESCRIPTION
...s.Getwd() for the config file to fix finding the config file in Windows issue.

This fixes https://github.com/spf13/hugo/issues/560. 

All remaining uses of `path` were switched to use `filepath` for os independence. 

Instead of returning an error if the config file isn't found via `findCWD()`, `os.Getwd()` is also searched. A failure here will return an error.

This is necessary because, in Windows, `findCWD()` returns the directory for the Hugo executable, which may or may not be the actual working directory that the user is in. For Windows, `os.Getwd()` returns this information.
