### PR TITLE
Fix missing package: path

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"runtime"


### PR DESCRIPTION
Simple patch to add back in the `path` package. Looks like it got left out in the last couple merges.

Fixes this:

```
$ go get -u github.com/spf13/viper
# github.com/spf13/viper
../go/src/github.com/spf13/viper/viper.go:624: undefined: path
```
