### PR TITLE
Avoid searching for config file in executable's path

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -777,15 +777,9 @@ func (v *viper) findConfigFile() (string, error) {
 		}
 	}
 
-	cwd, _ := findCWD()
-	file := v.searchInPath(cwd)
-	if file != "" {
-		return file, nil
-	}
-
 	// try the current working directory
 	wd, _ := os.Getwd()
-	file = v.searchInPath(wd)
+	file := v.searchInPath(wd)
 	if file != "" {
 		return file, nil
 	}


### PR DESCRIPTION
Viper should not be searching for config.{json,toml,yaml,yml}
in the directory where the `hugo` executable binary is located,
i.e. do not try to look for e.g. $GOPATH/bin/config.toml or
/usr/local/bin/config.toml

* * *

Hi @spf13,

When I was running `$GOPATH/bin/hugo` trying to figure out in what order Viper tries to load the config file (json, toml or yaml), I saw these debug messages:

```
DEBUG: 2015/01/22 Searching for config in  /home/foka/go/bin
DEBUG: 2015/01/22 Checking for /home/foka/go/bin/config.json
DEBUG: 2015/01/22 Checking for /home/foka/go/bin/config.toml
DEBUG: 2015/01/22 Checking for /home/foka/go/bin/config.yaml
DEBUG: 2015/01/22 Checking for /home/foka/go/bin/config.yml
DEBUG: 2015/01/22 Searching for config in  /work/web/anthonyfok.org
DEBUG: 2015/01/22 Checking for /work/web/anthonyfok.org/config.json
DEBUG: 2015/01/22 Checking for /work/web/anthonyfok.org/config.toml
DEBUG: 2015/01/22 Found:  /work/web/anthonyfok.org/config.toml
```

which reminds me of the `findCWD()` function again.  While I think it is worth keeping that function around for future uses, I don't think it should be used for locating config files for individual Hugo websites.

Thank you for your considerations.