### PR TITLE
Allow Marshal to use env and flags

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -313,23 +313,10 @@ func (v *viper) MarshalKey(key string, rawVal interface{}) error {
 // Marshals the config into a Struct
 func Marshal(rawVal interface{}) error { return v.Marshal(rawVal) }
 func (v *viper) Marshal(rawVal interface{}) error {
-	err := mapstructure.Decode(v.defaults, rawVal)
+	err := mapstructure.WeakDecode(v.AllSettings(), rawVal)
 	if err != nil {
 		return err
 	}
-	err = mapstructure.Decode(v.config, rawVal)
-	if err != nil {
-		return err
-	}
-	err = mapstructure.Decode(v.override, rawVal)
-	if err != nil {
-		return err
-	}
-	err = mapstructure.Decode(v.kvstore, rawVal)
-	if err != nil {
-		return err
-	}
-
 	v.insensativiseMaps()
 
 	return nil

--- a/viper.go
+++ b/viper.go
@@ -633,6 +633,14 @@ func (v *viper) AllKeys() []string {
 		m[key] = struct{}{}
 	}
 
+	for key, _ := range v.env {
+		m[key] = struct{}{}
+	}
+
+	for key, _ := range v.pflags {
+		m[key] = struct{}{}
+	}
+
 	for key, _ := range v.override {
 		m[key] = struct{}{}
 	}


### PR DESCRIPTION
This PR fixes the following issues:

1. Currently `Marshal` ignores `env` variables and `pflags` when marshaling the config data into a structure.

2. Currently `Marshal` uses the wrong order of precedence for the various config sources. The documentation states that it is defaults<k/v store<config<env<flags<overrides, but `Marshal` uses `defaults<config<k/v store<override`

Solution:

1. `Marshal` now uses the `AllSettings` method in order to get the appropriately overriden settings data.

2. Added `env` and `pflag` key checks in the `AllKeys` method in order to add their data to the return of `AllSettings` (which uses the keys to `Get` each value).

3. Switched to `WeakDecode` for marshaling the settings into the structure. This is necessary since `pflags`'values are always strings, even for numeric types. `WeakDecode` coerces those to the appropriate types for the corresponding fields.
