### PR TITLE
Support rewriting envvar keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Go configuration with fangs
 
 Viper is a complete configuration solution for go applications. It has
 been designed to work within an application to handle all types of
-configuration. It supports 
+configuration. It supports
 
 * setting defaults
 * reading from yaml, toml and json config files
@@ -167,7 +167,7 @@ Example:
 ### Remote Key/Value Store Support
 Viper will read a config string (as JSON, TOML, or YAML) retrieved from a
 path in a Key/Value store such as Etcd or Consul.  These values take precedence
-over default values, but are overriden by configuration values retrieved from disk, 
+over default values, but are overriden by configuration values retrieved from disk,
 flags, or environment variables.
 
 Viper uses [crypt](https://github.com/xordataexchange/crypt) to retrieve configuration
@@ -176,7 +176,7 @@ encrypted and have them automatically decrypted if you have the correct
 gpg keyring.  Encryption is optional.
 
 You can use remote configuration in conjunction with local configuration, or
-independently of it.  
+independently of it.
 
 `crypt` has a command-line helper that you can use to put configurations
 in your k/v store. `crypt` defaults to etcd on http://127.0.0.1:4001.
@@ -207,7 +207,7 @@ to use Consul.
 ## Getting Values From Viper
 
 In Viper there are a few ways to get a value depending on what type of value you want to retrieved.
-The following functions and methods exist: 
+The following functions and methods exist:
 
  * Get(key string) : interface{}
  * GetBool(key string) : bool

--- a/README.md
+++ b/README.md
@@ -98,12 +98,13 @@ Aliases permit a single value to be referenced by multiple keys
 ### Working with Environment Variables
 
 Viper has full support for environment variables. This enables 12 factor
-applications out of the box. There are three methods that exist to aid
+applications out of the box. There are four methods that exist to aid
 with working with ENV:
 
  * AutomaticEnv()
  * BindEnv(string...) : error
  * SetEnvPrefix(string)
+ * SetEnvReplacer(string...) *strings.Replacer
 
 _When working with ENV variables it’s important to recognize that Viper
 treats ENV variables as case sensitive._
@@ -130,6 +131,11 @@ SetEnvPrefix. When called, Viper will check for an environment variable
 any time a viper.Get request is made. It will apply the following rules.
 It will check for a environment variable with a name matching the key
 uppercased and prefixed with the EnvPrefix if set.
+
+SetEnvReplacer allows you to use a `strings.Replacer` object to rewrite Env keys
+to an extent. This is useful if you want to use `-` or something in your Get()
+calls, but want your environmental variables to use `_` delimiters. An example
+of using it can be found in `viper_test.go`
 
 #### Env example
 

--- a/viper_test.go
+++ b/viper_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -221,6 +222,7 @@ func TestEnv(t *testing.T) {
 	AutomaticEnv()
 
 	assert.Equal(t, "crunk", Get("name"))
+
 }
 
 func TestEnvPrefix(t *testing.T) {
@@ -258,6 +260,18 @@ func TestAutoEnvWithPrefix(t *testing.T) {
 	SetEnvPrefix("Baz")
 	os.Setenv("BAZ_BAR", "13")
 	assert.Equal(t, "13", Get("bar"))
+}
+
+func TestSetEnvReplacer(t *testing.T) {
+	Reset()
+
+	AutomaticEnv()
+	os.Setenv("REFRESH_INTERVAL", "30s")
+
+	replacer := strings.NewReplacer("-", "_")
+	SetEnvKeyReplacer(replacer)
+
+	assert.Equal(t, "30s", Get("refresh-interval"))
 }
 
 func TestAllKeys(t *testing.T) {


### PR DESCRIPTION
Use case is replacing `-` in my command line/viper keys with `_` when retrieving env vars.

```
viper.AutomaticEnv()
viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
```