### PR TITLE
Move viper.Reset() back to the public interface

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -102,6 +102,15 @@ func New() *viper {
 	return v
 }
 
+// Intended for testing, will reset all to default settings.
+// In the public interface for the viper package so applications
+// can use it in their testing as well.
+func Reset() {
+	v = New()
+	SupportedExts = []string{"json", "toml", "yaml", "yml"}
+	SupportedRemoteProviders = []string{"etcd", "consul"}
+}
+
 // remoteProvider stores the configuration necessary
 // to connect to a remote key/value store.
 // Optional secretKeyring to unencrypt encrypted values

--- a/viper_test.go
+++ b/viper_test.go
@@ -54,13 +54,6 @@ var jsonExample = []byte(`{
     }
 }`)
 
-// Intended for testing, will reset all to default settings.
-func Reset() {
-	v = New()
-	SupportedExts = []string{"json", "toml", "yaml", "yml"}
-	SupportedRemoteProviders = []string{"etcd", "consul"}
-}
-
 var remoteExample = []byte(`{
 "id":"0002",
 "type":"cronut",


### PR DESCRIPTION
It is helpful for applications that use viper to be able to
reset their configurations between test runs.

This will resolve #46 