### PR TITLE
Add GetSizeInBytes

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -313,6 +313,12 @@ func (v *viper) GetStringMapString(key string) map[string]string {
 	return cast.ToStringMapString(v.Get(key))
 }
 
+func GetSizeInBytes(key string) uint { return v.GetSizeInBytes(key) }
+func (v *viper) GetSizeInBytes(key string) uint {
+	sizeStr := cast.ToString(v.Get(key))
+	return parseSizeInBytes(sizeStr)
+}
+
 // Takes a single key and marshals it into a Struct
 func MarshalKey(key string, rawVal interface{}) error { return v.MarshalKey(key, rawVal) }
 func (v *viper) MarshalKey(key string, rawVal interface{}) error {

--- a/viper_test.go
+++ b/viper_test.go
@@ -362,3 +362,20 @@ func TestBoundCaseSensitivity(t *testing.T) {
 	assert.Equal(t, "green", Get("eyes"))
 
 }
+
+func TestSizeInBytes(t *testing.T) {
+	input := map[string]uint{
+		"":               0,
+		"b":              0,
+		"12 bytes":       0,
+		"200000000000gb": 0,
+		"12 b":           12,
+		"43 MB":          43 * (1 << 20),
+		"10mb":           10 * (1 << 20),
+		"1gb":            1 << 30,
+	}
+
+	for str, expected := range input {
+		assert.Equal(t, expected, parseSizeInBytes(str), str)
+	}
+}


### PR DESCRIPTION
Useful to parse strings like 1GB or 12 mb into an unsigned integer number of bytes. I was going to add this just to my own codebase, but realized that others can benefit.

I originally thought GetBytes() would be a good name, but it would conflict if you ever wanted to add a GetBytes() []byte to viper for some reason. GetSizeInBytes() is pretty clear.