### PR TITLE
Config path fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ currently a single viper only supports a single config file.
 	viper.SetConfigName("config") // name of config file (without extension)
 	viper.AddConfigPath("/etc/appname/")   // path to look for the config file in
 	viper.AddConfigPath("$HOME/.appname")  // call multiple times to add many search paths
-	viper.ReadInConfig() // Find and read the config file
+	err := viper.ReadInConfig() // Find and read the config file
+    if err != nil { // Handle errors reading the config file
+        panic(fmt.Errorf("Fatal error config file: %s \n", err))
+    }
 
 ### Setting Overrides
 

--- a/viper.go
+++ b/viper.go
@@ -100,6 +100,13 @@ func New() *Viper {
 	v.env = make(map[string]string)
 	v.aliases = make(map[string]string)
 
+	wd, err := os.Getwd()
+	if err != nil {
+		jww.INFO.Println("Could not add cwd to search paths", err)
+	} else {
+		v.AddConfigPath(wd)
+	}
+
 	return v
 }
 


### PR DESCRIPTION
This PR implements some of the feedback on how config files and paths are handled:

1. `pwd` is included in the search paths by default.
2. The `README` doc shows that `ReadInConfig` returns an error that can be handled.

Does not implement the suggestion that filepath extensions become optional - this needs some consideration.