### PR TITLE
Access to keys nested at an arbitrary depth

### DIFF
--- a/util.go
+++ b/util.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"unicode"
@@ -34,6 +35,10 @@ func insensitiviseMap(m map[string]interface{}) {
 		if key != lower {
 			delete(m, key)
 			m[lower] = val
+		}
+
+		if val != nil && reflect.TypeOf(val).Kind() == reflect.Map {
+			insensitiviseMap(cast.ToStringMap(val))
 		}
 	}
 }

--- a/viper.go
+++ b/viper.go
@@ -914,18 +914,18 @@ func (v *Viper) findConfigFile() (string, error) {
 // purposes.
 func Debug() { v.Debug() }
 func (v *Viper) Debug() {
-	fmt.Println("Config:")
-	pretty.Println(v.config)
-	fmt.Println("Key/Value Store:")
-	pretty.Println(v.kvstore)
-	fmt.Println("Env:")
-	pretty.Println(v.env)
-	fmt.Println("Defaults:")
-	pretty.Println(v.defaults)
-	fmt.Println("Override:")
-	pretty.Println(v.override)
 	fmt.Println("Aliases:")
 	pretty.Println(v.aliases)
+	fmt.Println("Override:")
+	pretty.Println(v.override)
 	fmt.Println("PFlags")
 	pretty.Println(v.pflags)
+	fmt.Println("Env:")
+	pretty.Println(v.env)
+	fmt.Println("Key/Value Store:")
+	pretty.Println(v.kvstore)
+	fmt.Println("Config:")
+	pretty.Println(v.config)
+	fmt.Println("Defaults:")
+	pretty.Println(v.defaults)
 }

--- a/viper_test.go
+++ b/viper_test.go
@@ -304,7 +304,7 @@ func TestAllKeys(t *testing.T) {
 
 	ks := sort.StringSlice{"title", "newkey", "owner", "name", "beard", "ppu", "batters", "hobbies", "clothing", "age", "hacker", "id", "type", "eyes", "p_id", "p_ppu", "p_batters.batter.type", "p_type", "p_name"}
 	dob, _ := time.Parse(time.RFC3339, "1979-05-27T07:32:00Z")
-	all := map[string]interface{}{"owner": map[string]interface{}{"organization": "MongoDB", "Bio": "MongoDB Chief Developer Advocate & Hacker at Large", "dob": dob}, "title": "TOML Example", "ppu": 0.55, "eyes": "brown", "clothing": map[interface{}]interface{}{"trousers": "denim", "jacket": "leather"}, "id": "0001", "batters": map[string]interface{}{"batter": []interface{}{map[string]interface{}{"type": "Regular"}, map[string]interface{}{"type": "Chocolate"}, map[string]interface{}{"type": "Blueberry"}, map[string]interface{}{"type": "Devil's Food"}}}, "hacker": true, "beard": true, "hobbies": []interface{}{"skateboarding", "snowboarding", "go"}, "age": 35, "type": "donut", "newkey": "remote", "name": "Cake", "p_id": "0001", "p_ppu": "0.55", "p_name": "Cake", "p_batters.batter.type": "Regular", "p_type": "donut"}
+	all := map[string]interface{}{"owner": map[string]interface{}{"organization": "MongoDB", "bio": "MongoDB Chief Developer Advocate & Hacker at Large", "dob": dob}, "title": "TOML Example", "ppu": 0.55, "eyes": "brown", "clothing": map[interface{}]interface{}{"trousers": "denim", "jacket": "leather"}, "id": "0001", "batters": map[string]interface{}{"batter": []interface{}{map[string]interface{}{"type": "Regular"}, map[string]interface{}{"type": "Chocolate"}, map[string]interface{}{"type": "Blueberry"}, map[string]interface{}{"type": "Devil's Food"}}}, "hacker": true, "beard": true, "hobbies": []interface{}{"skateboarding", "snowboarding", "go"}, "age": 35, "type": "donut", "newkey": "remote", "name": "Cake", "p_id": "0001", "p_ppu": "0.55", "p_name": "Cake", "p_batters.batter.type": "Regular", "p_type": "donut"}
 
 	var allkeys sort.StringSlice
 	allkeys = AllKeys()
@@ -512,10 +512,10 @@ func TestFindsNestedKeys(t *testing.T) {
 		"age":  35,
 		"owner": map[string]interface{}{
 			"organization": "MongoDB",
-			"Bio":          "MongoDB Chief Developer Advocate & Hacker at Large",
+			"bio":          "MongoDB Chief Developer Advocate & Hacker at Large",
 			"dob":          dob,
 		},
-		"owner.Bio": "MongoDB Chief Developer Advocate & Hacker at Large",
+		"owner.bio": "MongoDB Chief Developer Advocate & Hacker at Large",
 		"type":      "donut",
 		"id":        "0001",
 		"name":      "Cake",

--- a/viper_test.go
+++ b/viper_test.go
@@ -453,3 +453,87 @@ func TestSizeInBytes(t *testing.T) {
 		assert.Equal(t, expected, parseSizeInBytes(str), str)
 	}
 }
+
+func TestFindsNestedKeys(t *testing.T) {
+	initConfigs()
+	dob, _ := time.Parse(time.RFC3339, "1979-05-27T07:32:00Z")
+
+	Set("super", map[string]interface{}{
+		"deep": map[string]interface{}{
+			"nested": "value",
+		},
+	})
+
+	expected := map[string]interface{}{
+		"super": map[string]interface{}{
+			"deep": map[string]interface{}{
+				"nested": "value",
+			},
+		},
+		"super.deep": map[string]interface{}{
+			"nested": "value",
+		},
+		"super.deep.nested":  "value",
+		"owner.organization": "MongoDB",
+		"batters.batter": []interface{}{
+			map[string]interface{}{
+				"type": "Regular",
+			},
+			map[string]interface{}{
+				"type": "Chocolate",
+			},
+			map[string]interface{}{
+				"type": "Blueberry",
+			},
+			map[string]interface{}{
+				"type": "Devil's Food",
+			},
+		},
+		"hobbies": []interface{}{
+			"skateboarding", "snowboarding", "go",
+		},
+		"title":  "TOML Example",
+		"newkey": "remote",
+		"batters": map[string]interface{}{
+			"batter": []interface{}{
+				map[string]interface{}{
+					"type": "Regular",
+				},
+				map[string]interface{}{
+					"type": "Chocolate",
+				}, map[string]interface{}{
+					"type": "Blueberry",
+				}, map[string]interface{}{
+					"type": "Devil's Food",
+				},
+			},
+		},
+		"eyes": "brown",
+		"age":  35,
+		"owner": map[string]interface{}{
+			"organization": "MongoDB",
+			"Bio":          "MongoDB Chief Developer Advocate & Hacker at Large",
+			"dob":          dob,
+		},
+		"owner.Bio": "MongoDB Chief Developer Advocate & Hacker at Large",
+		"type":      "donut",
+		"id":        "0001",
+		"name":      "Cake",
+		"hacker":    true,
+		"ppu":       0.55,
+		"clothing": map[interface{}]interface{}{
+			"jacket":   "leather",
+			"trousers": "denim",
+		},
+		"clothing.jacket":   "leather",
+		"clothing.trousers": "denim",
+		"owner.dob":         dob,
+		"beard":             true,
+	}
+
+	for key, expectedValue := range expected {
+
+		assert.Equal(t, expectedValue, v.Get(key))
+	}
+
+}


### PR DESCRIPTION
This accomplishes the same as #54 , but in a better way given the current Viper implementation since it does not rebuild the indexes on every operation, but rather uses recursive search though the registers.

This adds the ability to access keys nested in an arbitrary number of maps by passing a delimited string such as:
`databases.metrics.host`

It works in the following manner:

1. First, checks for the existence of the key as is, e.g. looks up the value of `databases.metrics.host`.

2. If nothing is found, the key is split on the delimiter (`.`). The root source is looked up by finding the first part of the path (`databases`) in this case. 

3. If the root source is a map, recursively looks for each part of the path. So first the root source will be searched for the value of the `metrics` key, and if that is a map, it will be searched for the `host` key. If all of these succeed, the value of `host` is returned.

Notes:

1. Only the first encountered source is used. So if the following situation occurs:
```
configs = {
    "databases": {}
},
defaults = {
    "databases": {
        "metrics": {
            "host": "localhost"
         }
    }
}
```
searching for `databases.metrics.host` will return `nil`, even though the `defaults` registry contains a value for the key.

2. Only the first part of the path is case insensitive. This is due to how Viper has behaved up to this point: when a config is loaded, only the surface keys are insensitivized, without recursing deeper. So the 2nd and 3rd, etc, level keys might be in mixed case. @spf13 what is your opinion on this - keep the current solution which maintains the established behavior, or recursively insensitivize everything?

3. Obviously, keys that include the delimiter will cause issues. Maybe the delimiter should be configurable/escapable?