### PR TITLE
Avoid searching CWD if no config in provided dirs

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -981,7 +981,7 @@ func (v *Viper) findConfigInPaths() (string, error) {
 }
 
 // Search the current working directory for any config file.
-func (v *Viper) findConfigInCWD() (string, error) {
+func (v *Viper) findConfigInWD() (string, error) {
 
 	wd, _ := os.Getwd()
 	jww.INFO.Println("Searching for config in ", wd)

--- a/viper.go
+++ b/viper.go
@@ -955,9 +955,20 @@ func (v *Viper) searchInPath(in string) (filename string) {
 	return ""
 }
 
-// search all configPaths for any config file.
-// Returns the first path that exists (and is a config file)
+// Choose where to look for a config file: either
+// in provided directories or in the working directory
 func (v *Viper) findConfigFile() (string, error) {
+	if len(v.configPaths) > 0 {
+		return v.findConfigInPaths()
+	} else {
+		return v.findConfigInWD()
+	}
+}
+
+// Search all configPaths for any config file.
+// Returns the first path that exists (and has a config file)
+func (v *Viper) findConfigInPaths() (string, error) {
+
 	jww.INFO.Println("Searching for config in ", v.configPaths)
 
 	for _, cp := range v.configPaths {
@@ -966,18 +977,20 @@ func (v *Viper) findConfigFile() (string, error) {
 			return file, nil
 		}
 	}
+	return "", fmt.Errorf("config file not found in: %s", v.configPaths)
+}
 
-	if len(v.configPaths) > 0 {
-		return "", fmt.Errorf("Config file not found in: %s", v.configPaths)
-	}
+// Search the current working directory for any config file.
+func (v *Viper) findConfigInCWD() (string, error) {
 
-	// try the current working directory
 	wd, _ := os.Getwd()
+	jww.INFO.Println("Searching for config in ", wd)
+
 	file := v.searchInPath(wd)
 	if file != "" {
 		return file, nil
 	}
-	return "", fmt.Errorf("config file not found in the current working directory %q", wd)
+	return "", fmt.Errorf("config file not found in current working directory", v.configPaths)
 }
 
 // Prints all configuration registries for debugging

--- a/viper.go
+++ b/viper.go
@@ -50,7 +50,7 @@ type UnsupportedConfigError string
 
 // Returns the formatted configuration error.
 func (str UnsupportedConfigError) Error() string {
-	return fmt.Sprintf("Unsupported Config Type %q", string(str))
+	return fmt.Sprintf("Unsupported Config Type %q or Config File Not Found", string(str))
 }
 
 // Denotes encountering an unsupported remote
@@ -967,13 +967,17 @@ func (v *Viper) findConfigFile() (string, error) {
 		}
 	}
 
+	if len(v.configPaths) > 0 {
+		return "", fmt.Errorf("Config file not found in: %s", v.configPaths)
+	}
+
 	// try the current working directory
 	wd, _ := os.Getwd()
 	file := v.searchInPath(wd)
 	if file != "" {
 		return file, nil
 	}
-	return "", fmt.Errorf("config file not found in: %s", v.configPaths)
+	return "", fmt.Errorf("config file not found in the current working directory %q", wd)
 }
 
 // Prints all configuration registries for debugging

--- a/viper_test.go
+++ b/viper_test.go
@@ -148,7 +148,7 @@ func (s *stringValue) String() string {
 func TestBasics(t *testing.T) {
 	SetConfigFile("/tmp/config.yaml")
 	cf, err := v.getConfigFile()
-	assert.Equal(t, nil, err)
+	assert.Nil(t, err)
 	assert.Equal(t, "/tmp/config.yaml", cf)
 }
 

--- a/viper_test.go
+++ b/viper_test.go
@@ -147,7 +147,9 @@ func (s *stringValue) String() string {
 
 func TestBasics(t *testing.T) {
 	SetConfigFile("/tmp/config.yaml")
-	assert.Equal(t, "/tmp/config.yaml", v.getConfigFile())
+	cf, err := v.getConfigFile()
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "/tmp/config.yaml", cf)
 }
 
 func TestDefault(t *testing.T) {


### PR DESCRIPTION
Address #73. Clarify specific error messages. Propagating errors properly up to the public function caller.