### PR TITLE
AddSecureRemoteProvider missing secretKeyring to remoteProvider

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -288,6 +288,7 @@ func (v *Viper) AddSecureRemoteProvider(provider, endpoint, path, secretkeyring 
 			endpoint: endpoint,
 			provider: provider,
 			path:     path,
+			secretKeyring: secretkeyring,
 		}
 		if !v.providerPathExists(rp) {
 			v.remoteProviders = append(v.remoteProviders, rp)


### PR DESCRIPTION
I set up viper with a encrypted crypt storage and couldn't decrypt anything. The error was that it was unable to wrangle it to json (I can't remember the exact). When I dug in the code, I found that when AddSecureRemoteProvider added the remoteProvider struct, it wasn't passing in the secretKeyring field so nothing was getting decrypted and the raw ascii armor'd gpg stuff was getting returned instead (hence the json marshaling failure).