### PR TITLE
Fixed #115: Added code in the find method to search for nested configuration parameters

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -657,6 +657,20 @@ func (v *Viper) find(key string) interface{} {
 		return val
 	}
 
+	// Test for nested config parameter
+	if strings.Contains(key, v.keyDelim) {
+		path := strings.Split(key, v.keyDelim)
+
+		source := v.find(path[0])
+		if source != nil {
+			if reflect.TypeOf(source).Kind() == reflect.Map {
+				val := v.searchMap(cast.ToStringMap(source), path[1:])
+				jww.TRACE.Println(key, "found in nested config:", val)
+				return val
+			}
+		}
+	}
+
 	val, exists = v.kvstore[key]
 	if exists {
 		jww.TRACE.Println(key, "found in key/value store:", val)

--- a/viper_test.go
+++ b/viper_test.go
@@ -199,6 +199,15 @@ func TestBasics(t *testing.T) {
 func TestDefault(t *testing.T) {
 	SetDefault("age", 45)
 	assert.Equal(t, 45, Get("age"))
+
+	SetDefault("clothing.jacket", "slacks")
+	assert.Equal(t, "slacks", Get("clothing.jacket"))
+
+	SetConfigType("yaml")
+	err := ReadConfig(bytes.NewBuffer(yamlExample))
+
+	assert.NoError(t, err)
+	assert.Equal(t, "leather", Get("clothing.jacket"))
 }
 
 func TestUnmarshalling(t *testing.T) {


### PR DESCRIPTION
As described in Issue #115, nested configuration defaults do not work. It was caused because the find method tried to search the config for the value which failed causing it to always return the default value to the Get function.