### PR TITLE
AllKeys() now includes bound flag and env var keys

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -962,19 +962,27 @@ func (v *Viper) AllKeys() []string {
 	m := map[string]struct{}{}
 
 	for key, _ := range v.defaults {
-		m[key] = struct{}{}
+		m[strings.ToLower(key)] = struct{}{}
+	}
+
+	for key, _ := range v.pflags {
+		m[strings.ToLower(key)] = struct{}{}
+	}
+
+	for key, _ := range v.env {
+		m[strings.ToLower(key)] = struct{}{}
 	}
 
 	for key, _ := range v.config {
-		m[key] = struct{}{}
+		m[strings.ToLower(key)] = struct{}{}
 	}
 
 	for key, _ := range v.kvstore {
-		m[key] = struct{}{}
+		m[strings.ToLower(key)] = struct{}{}
 	}
 
 	for key, _ := range v.override {
-		m[key] = struct{}{}
+		m[strings.ToLower(key)] = struct{}{}
 	}
 
 	a := []string{}


### PR DESCRIPTION
This patch fixes a bug where the function `AllKeys()` did not include the keys for bound flags and environment variables.