### PR TITLE
Refactored IsSet to examine keys

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -742,8 +742,21 @@ func (v *Viper) find(key string) interface{} {
 // Check to see if the key has been set in any of the data locations
 func IsSet(key string) bool { return v.IsSet(key) }
 func (v *Viper) IsSet(key string) bool {
-	t := v.Get(key)
-	return t != nil
+	path := strings.Split(key, v.keyDelim)
+
+	lcaseKey := strings.ToLower(key)
+	val := v.find(lcaseKey)
+
+	if val == nil {
+		source := v.find(strings.ToLower(path[0]))
+		if source != nil {
+			if reflect.TypeOf(source).Kind() == reflect.Map {
+				val = v.searchMap(cast.ToStringMap(source), path[1:])
+			}
+		}
+	}
+
+	return val != nil
 }
 
 // Have Viper check ENV variables for all

--- a/viper_test.go
+++ b/viper_test.go
@@ -611,6 +611,17 @@ func TestReadBufConfig(t *testing.T) {
 	assert.Equal(t, 35, v.Get("age"))
 }
 
+func TestIsSet(t *testing.T) {
+	v := New()
+	v.SetConfigType("yaml")
+	v.ReadConfig(bytes.NewBuffer(yamlExample))
+	assert.True(t, v.IsSet("clothing.jacket"))
+	assert.False(t, v.IsSet("clothing.jackets"))
+	assert.False(t, v.IsSet("helloworld"))
+	v.Set("helloworld", "fubar")
+	assert.True(t, v.IsSet("helloworld"))
+}
+
 func TestDirsSearch(t *testing.T) {
 
 	root, config, cleanup := initDirs(t)


### PR DESCRIPTION
This patch refactors the IsSet function to examine the keys in order to see if a key is set instead of simply checking if a value is nil. This change is necessary due to the fact that default values via flag bindings will result in the old logic always being true for the IsSet function due to a type's default value such as 0 for an integer or an empty string for a string. While a type's default value may be preferable when getting the value for a key, it results in a false positive when determining if a key is actually set. This change enables users to detect whether a key is set by only returning a flag's value if it has changed.