### PR TITLE
Adding an Unmarshal Function that errors when a field in the conf is not present in the destination struct

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -623,6 +623,37 @@ func (v *Viper) Unmarshal(rawVal interface{}) error {
 	return nil
 }
 
+// A wrapper around mapstructure.Decode that mimics the WeakDecode functionality
+// while erroring on non existing vals in the destination struct
+func weakDecodeExact(input, output interface{}) error {
+	config := &mapstructure.DecoderConfig{
+		ErrorUnused:      true,
+		Metadata:         nil,
+		Result:           output,
+		WeaklyTypedInput: true,
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return err
+	}
+	return decoder.Decode(input)
+}
+
+// Unmarshals the config into a Struct, erroring if a field is non-existant
+// in the destination struct
+func (v *Viper) UnmarshalExact(rawVal interface{}) error {
+	err := weakDecodeExact(v.AllSettings(), rawVal)
+
+	if err != nil {
+		return err
+	}
+
+	v.insensitiviseMaps()
+
+	return nil
+}
+
 // Bind a full flag set to the configuration, using each flag's long
 // name as the config key.
 func BindPFlags(flags *pflag.FlagSet) (err error) { return v.BindPFlags(flags) }

--- a/viper_test.go
+++ b/viper_test.go
@@ -37,6 +37,14 @@ eyes : brown
 beard: true
 `)
 
+var yamlExampleWithExtras = []byte(`Existing: true
+Bogus: true
+`)
+
+type testUnmarshalExtra struct {
+	Existing bool
+}
+
 var tomlExample = []byte(`
 title = "TOML Example"
 
@@ -253,6 +261,18 @@ func TestUnmarshalling(t *testing.T) {
 	assert.Equal(t, []interface{}{"skateboarding", "snowboarding", "go"}, Get("hobbies"))
 	assert.Equal(t, map[interface{}]interface{}{"jacket": "leather", "trousers": "denim", "pants": map[interface{}]interface{}{"size": "large"}}, Get("clothing"))
 	assert.Equal(t, 35, Get("age"))
+}
+
+func TestUnmarshalExact(t *testing.T) {
+	vip := New()
+	target := &testUnmarshalExtra{}
+	vip.SetConfigType("yaml")
+	r := bytes.NewReader(yamlExampleWithExtras)
+	vip.ReadConfig(r)
+	err := vip.UnmarshalExact(target)
+	if err == nil {
+		t.Fatal("UnmarshalExact should error when populating a struct from a conf that contains unused fields")
+	}
 }
 
 func TestOverrides(t *testing.T) {
@@ -844,14 +864,14 @@ func TestUnmarshalingWithAliases(t *testing.T) {
 	Set("name", "Steve")
 	Set("lastname", "Owen")
 
-	RegisterAlias("UserID","Id")
-	RegisterAlias("Firstname","name")
-	RegisterAlias("Surname","lastname")
+	RegisterAlias("UserID", "Id")
+	RegisterAlias("Firstname", "name")
+	RegisterAlias("Surname", "lastname")
 
 	type config struct {
-		Id int
+		Id        int
 		FirstName string
-		Surname string
+		Surname   string
 	}
 
 	var C config


### PR DESCRIPTION
This functions protects from configs that might have unused or mistyped fields when unmarshalling into a struct. The relevant test passes.