### PR TITLE
use aliases in all keys list to enable proper Unmarshaling

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1149,6 +1149,10 @@ func (v *Viper) AllKeys() []string {
 		m[strings.ToLower(key)] = struct{}{}
 	}
 
+	for key, _ := range v.aliases {
+		m[strings.ToLower(key)] = struct{}{}
+	}
+
 	a := []string{}
 	for x, _ := range m {
 		a = append(a, x)

--- a/viper_test.go
+++ b/viper_test.go
@@ -838,3 +838,28 @@ func TestMergeConfigNoMerge(t *testing.T) {
 		t.Fatalf("fu != \"bar\", = %s", fu)
 	}
 }
+
+func TestUnmarshalingWithAliases(t *testing.T) {
+	SetDefault("Id", 1)
+	Set("name", "Steve")
+	Set("lastname", "Owen")
+
+	RegisterAlias("UserID","Id")
+	RegisterAlias("Firstname","name")
+	RegisterAlias("Surname","lastname")
+
+	type config struct {
+		Id int
+		FirstName string
+		Surname string
+	}
+
+	var C config
+
+	err := Unmarshal(&C)
+	if err != nil {
+		t.Fatalf("unable to decode into struct, %v", err)
+	}
+
+	assert.Equal(t, &C, &config{Id: 1, FirstName: "Steve", Surname: "Owen"})
+}


### PR DESCRIPTION
I added support for aliasing in Unmarashalling, of course I can use StructTag "mapstructure" like here: https://github.com/spf13/viper#unmarshaling but in this case we remap it not alias it,  so you cannot use original key, only new remaped one. That will be helpful in config evolution.

In addition it looks like inconsistency in alias behavior across whole lib. 