### PR TITLE
Prevent shadowning of keys when a nested key's value is nil.

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -757,8 +757,10 @@ func (v *Viper) find(key string) interface{} {
 		if source != nil {
 			if reflect.TypeOf(source).Kind() == reflect.Map {
 				val := v.searchMap(cast.ToStringMap(source), path[1:])
-				jww.TRACE.Println(key, "found in nested config:", val)
-				return val
+				if val != nil {
+					jww.TRACE.Println(key, "found in nested config:", val)
+					return val
+				}
 			}
 		}
 	}

--- a/viper.go
+++ b/viper.go
@@ -950,6 +950,18 @@ func (v *Viper) MergeConfig(in io.Reader) error {
 	return nil
 }
 
+// Merge a configuration into another.
+func Merge( other *Viper ) { v.Merge( other ) }
+func (v *Viper) Merge( other *Viper ) {
+	mergeMaps( other.config, v.config, nil )
+	mergeMaps( other.override, v.override, nil )
+	mergeMaps( other.defaults, v.defaults, nil )
+	mergeMaps( other.kvstore, v.kvstore, nil )
+	for key,val := range other.pflags { v.pflags[key] = val }
+	for key,val := range other.env { v.env[key] = val }
+	for key,val := range other.aliases { v.aliases[key] = val }
+}
+
 func keyExists(k string, m map[string]interface{}) string {
 	lk := strings.ToLower(k)
 	for mk := range m {

--- a/viper.go
+++ b/viper.go
@@ -950,18 +950,6 @@ func (v *Viper) MergeConfig(in io.Reader) error {
 	return nil
 }
 
-// Merge a configuration into another.
-func Merge( other *Viper ) { v.Merge( other ) }
-func (v *Viper) Merge( other *Viper ) {
-	mergeMaps( other.config, v.config, nil )
-	mergeMaps( other.override, v.override, nil )
-	mergeMaps( other.defaults, v.defaults, nil )
-	mergeMaps( other.kvstore, v.kvstore, nil )
-	for key,val := range other.pflags { v.pflags[key] = val }
-	for key,val := range other.env { v.env[key] = val }
-	for key,val := range other.aliases { v.aliases[key] = val }
-}
-
 func keyExists(k string, m map[string]interface{}) string {
 	lk := strings.ToLower(k)
 	for mk := range m {


### PR DESCRIPTION
The change enables setting defaults for nested keys w/o those keys being shadowed by non-existent configuration values (nil) when read from a file.

For example:
```go
viper.SetDefault("nested.one","foo")
...
viper.ReadInConfig()     // { "nested" : { "two" : "bar" } }
...
```
Following the configuration read the "nested.one" will become inaccessible w/o this change.
