### PR TITLE
Allow errors to propagate through getConfigFile()

### DIFF
--- a/viper_test.go
+++ b/viper_test.go
@@ -225,7 +225,9 @@ func (s *stringValue) String() string {
 
 func TestBasics(t *testing.T) {
 	SetConfigFile("/tmp/config.yaml")
-	assert.Equal(t, "/tmp/config.yaml", v.getConfigFile())
+	filename, err := v.getConfigFile()
+	assert.Equal(t, "/tmp/config.yaml", filename)
+	assert.NoError(t, err)
 }
 
 func TestDefault(t *testing.T) {
@@ -718,7 +720,7 @@ func TestWrongDirsSearchNotFound(t *testing.T) {
 	v.AddConfigPath(`thispathaintthere`)
 
 	err := v.ReadInConfig()
-	assert.Equal(t, reflect.TypeOf(UnsupportedConfigError("")), reflect.TypeOf(err))
+	assert.Equal(t, reflect.TypeOf(ConfigFileNotFoundError{"", ""}), reflect.TypeOf(err))
 
 	// Even though config did not load and the error might have
 	// been ignored by the client, the default still loads


### PR DESCRIPTION
Currently, when I run a Viper-enabled application without a configuration file, expecting it to just use the default values, I see a slightly unintuitive error: `Unsupported Config Type ""`. When I *write* an application with Viper, I have no way to distinguish between configuration file errors and users who have chosen not to write an explicit config file. Although `findConfigFile()` can return a `ConfigFileNotFoundError`, some of its callers (e.g., `getConfigFile()`) silently drop the error, resulting in lots of `""` strings with no explanation. Code like `ReadInConfig()` must then re-construct the error without information about why it occurred, so "there is no config file" is conflated with "the config file is not a valid format".

This patch changes `getConfigFile()` to propagate the error to its caller, allowing applications to handle the "no config file" case differently from other file-reading errors. It also means that, when no configuration file is found, `ReadInConfig()` can return a `ConfigFileNotFoundError` rather than an `UnsupportedConfigError`.