### PR TITLE
Prevent shadowning of keys when a nested key's value is nil.

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -788,8 +788,10 @@ func (v *Viper) find(key string) interface{} {
 		if source != nil {
 			if reflect.TypeOf(source).Kind() == reflect.Map {
 				val := v.searchMap(cast.ToStringMap(source), path[1:])
-				jww.TRACE.Println(key, "found in nested config:", val)
-				return val
+				if val != nil {
+					jww.TRACE.Println(key, "found in nested config:", val)
+					return val
+				}
 			}
 		}
 	}

--- a/viper_test.go
+++ b/viper_test.go
@@ -883,3 +883,12 @@ func TestUnmarshalingWithAliases(t *testing.T) {
 
 	assert.Equal(t, &C, &config{Id: 1, FirstName: "Steve", Surname: "Owen"})
 }
+
+func TestShadowedNestedValue(t *testing.T) {
+	polyester := "polyester"
+	initYAML()
+	SetDefault("clothing.shirt", polyester)
+
+	assert.Equal(t, GetString("clothing.jacket"), "leather")
+	assert.Equal(t, GetString("clothing.shirt"), polyester)
+}


### PR DESCRIPTION
This is taking the change request #156  and adding the test case.  I ran into the same problem so added a test case that fails without the fix.

Copied from #156 for easy access:

The change enables setting defaults for nested keys w/o those keys being shadowed by non-existent configuration values (nil) when read from a file.

For example:

```go
viper.SetDefault("nested.one","foo")
...
viper.ReadInConfig()     // { "nested" : { "two" : "bar" } }
...
```
Following the configuration read the "nested.one" will become inaccessible w/o this change.