### PR TITLE
enhance(remote): one RemoteProvider support multiple addresses

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -12,6 +12,7 @@ import (
 	crypt "github.com/xordataexchange/crypt/config"
 	"io"
 	"os"
+	"strings"
 )
 
 type remoteConfigProvider struct{}
@@ -54,15 +55,15 @@ func getConfigManager(rp viper.RemoteProvider) (crypt.ConfigManager, error) {
 			return nil, err
 		}
 		if rp.Provider() == "etcd" {
-			cm, err = crypt.NewEtcdConfigManager([]string{rp.Endpoint()}, kr)
+			cm, err = crypt.NewEtcdConfigManager(toMachines(rp.Endpoint()), kr)
 		} else {
-			cm, err = crypt.NewConsulConfigManager([]string{rp.Endpoint()}, kr)
+			cm, err = crypt.NewConsulConfigManager(toMachines(rp.Endpoint()), kr)
 		}
 	} else {
 		if rp.Provider() == "etcd" {
-			cm, err = crypt.NewStandardEtcdConfigManager([]string{rp.Endpoint()})
+			cm, err = crypt.NewStandardEtcdConfigManager(toMachines(rp.Endpoint()))
 		} else {
-			cm, err = crypt.NewStandardConsulConfigManager([]string{rp.Endpoint()})
+			cm, err = crypt.NewStandardConsulConfigManager(toMachines(rp.Endpoint()))
 		}
 	}
 	if err != nil {
@@ -70,6 +71,11 @@ func getConfigManager(rp viper.RemoteProvider) (crypt.ConfigManager, error) {
 	}
 	return cm, nil
 
+}
+
+func toMachines(endpoint string) []string {
+	machines := strings.Split(endpoint, ",")
+	return machines
 }
 
 func init() {

--- a/viper.go
+++ b/viper.go
@@ -326,9 +326,10 @@ func (v *Viper) AddConfigPath(in string) {
 }
 
 // AddRemoteProvider adds a remote configuration source.
-// Remote Providers are searched in the order they are added.
+// Remote Providers are searched in the order they are added, and use first found provider.
 // provider is a string value, "etcd" or "consul" are currently supported.
 // endpoint is the url.  etcd requires http://ip:port  consul requires ip:port
+// multiple addresses can configured in one url separated by commas
 // path is the path in the k/v store to retrieve configuration
 // To retrieve a config file called myapp.json from /configs/myapp.json
 // you should set path to /configs and set config name (SetConfigName()) to
@@ -1156,36 +1157,36 @@ func AllKeys() []string { return v.AllKeys() }
 func (v *Viper) AllKeys() []string {
 	m := map[string]struct{}{}
 
-	for key, _ := range v.defaults {
+	for key := range v.defaults {
 		m[strings.ToLower(key)] = struct{}{}
 	}
 
-	for key, _ := range v.pflags {
+	for key := range v.pflags {
 		m[strings.ToLower(key)] = struct{}{}
 	}
 
-	for key, _ := range v.env {
+	for key := range v.env {
 		m[strings.ToLower(key)] = struct{}{}
 	}
 
-	for key, _ := range v.config {
+	for key := range v.config {
 		m[strings.ToLower(key)] = struct{}{}
 	}
 
-	for key, _ := range v.kvstore {
+	for key := range v.kvstore {
 		m[strings.ToLower(key)] = struct{}{}
 	}
 
-	for key, _ := range v.override {
+	for key := range v.override {
 		m[strings.ToLower(key)] = struct{}{}
 	}
 
-	for key, _ := range v.aliases {
+	for key := range v.aliases {
 		m[strings.ToLower(key)] = struct{}{}
 	}
 
 	a := []string{}
-	for x, _ := range m {
+	for x := range m {
 		a = append(a, x)
 	}
 


### PR DESCRIPTION
- split provider url by commas
- update `AddRemoteProvider` comment

and it enable us to can configure multiple addresses in one provider and using `etcd` or `consul` client to distribute requests to different servers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spf13/viper/169)
<!-- Reviewable:end -->
