### PR TITLE
Fix `Sub` to work with mixed-case subtrees

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -526,7 +526,10 @@ func (v *Viper) Sub(key string) *Viper {
 	subv := New()
 	data := v.Get(key)
 	if reflect.TypeOf(data).Kind() == reflect.Map {
-		subv.config = cast.ToStringMap(data)
+		m := cast.ToStringMap(data)
+		for k, v := range m {
+			subv.config[strings.ToLower(k)] = v
+		}
 		return subv
 	} else {
 		return nil

--- a/viper_test.go
+++ b/viper_test.go
@@ -41,6 +41,15 @@ var yamlExampleWithExtras = []byte(`Existing: true
 Bogus: true
 `)
 
+var yamlExampleWithSubtreeCaps = []byte(`Hacker: true
+name: steve
+clothing:
+  JACKET: leather
+  TROUSERS: denim
+  pants:
+    size: large
+`)
+
 type testUnmarshalExtra struct {
 	Existing bool
 }
@@ -755,6 +764,18 @@ func TestSub(t *testing.T) {
 
 	subv = v.Sub("clothing.pants")
 	assert.Equal(t, v.Get("clothing.pants.size"), subv.Get("size"))
+
+	subv = v.Sub("clothing.pants.size")
+	assert.Equal(t, subv, (*Viper)(nil))
+}
+
+func TestSubWithCaps(t *testing.T) {
+	v := New()
+	v.SetConfigType("yaml")
+	v.ReadConfig(bytes.NewBuffer(yamlExampleWithSubtreeCaps))
+
+	subv := v.Sub("clothing")
+	assert.Equal(t, v.Get("clothing.JACKET"), subv.Get("jacket"))
 
 	subv = v.Sub("clothing.pants.size")
 	assert.Equal(t, subv, (*Viper)(nil))


### PR DESCRIPTION
Viper assumes that the top level of the config is lower case. However it
doesn't have this same restriction for sub trees, so you can get in a
sutation where a Viper instance returned by `Sub` has a config with
upper case keys, but all the accessors lowercase the keys.

Also adds a test for the usecase.