### PR TITLE
Add support for Afero filesystems

### DIFF
--- a/util.go
+++ b/util.go
@@ -77,7 +77,7 @@ func absPathify(inPath string) string {
 
 // Check if File / Directory Exists
 func exists(path string) (bool, error) {
-	_, err := os.Stat(path)
+	_, err := fs.Stat(path)
 	if err == nil {
 		return true, nil
 	}

--- a/viper.go
+++ b/viper.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -33,15 +32,18 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/afero"
 	"github.com/spf13/cast"
 	jww "github.com/spf13/jwalterweatherman"
 	"github.com/spf13/pflag"
 )
 
 var v *Viper
+var fs afero.Fs
 
 func init() {
 	v = New()
+	fs = afero.NewOsFs()
 }
 
 type remoteConfigFactory interface {
@@ -930,7 +932,7 @@ func (v *Viper) ReadInConfig() error {
 		return UnsupportedConfigError(v.getConfigType())
 	}
 
-	file, err := ioutil.ReadFile(v.getConfigFile())
+	file, err := afero.ReadFile(fs, v.getConfigFile())
 	if err != nil {
 		return err
 	}
@@ -948,7 +950,7 @@ func (v *Viper) MergeInConfig() error {
 		return UnsupportedConfigError(v.getConfigType())
 	}
 
-	file, err := ioutil.ReadFile(v.getConfigFile())
+	file, err := afero.ReadFile(fs, v.getConfigFile())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Hi there,

I was in the process of implementing some unit tests for a config write feature (as described in https://github.com/spf13/viper/pull/153), and noticed that Viper does not currently use the Afero filesystem framework.

It would be nice if Viper used the Afero backend as it would allow for mock filesystems in unit tests.

Let me know if I have missed anything or if something should be changed!