### PR TITLE
Changing config name should also reset file name cache

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1208,6 +1208,7 @@ func SetConfigName(in string) { v.SetConfigName(in) }
 func (v *Viper) SetConfigName(in string) {
 	if in != "" {
 		v.configName = in
+		v.configFile = ""
 	}
 }
 

--- a/viper_test.go
+++ b/viper_test.go
@@ -883,3 +883,9 @@ func TestUnmarshalingWithAliases(t *testing.T) {
 
 	assert.Equal(t, &C, &config{Id: 1, FirstName: "Steve", Surname: "Owen"})
 }
+
+func TestSetConfigNameClearsFileCache(t *testing.T) {
+	SetConfigFile("/tmp/config.yaml")
+	SetConfigName("default")
+	assert.Empty(t, v.getConfigFile())
+}


### PR DESCRIPTION
I stumbled over this when trying to merge multiple configs.

```
viper.SetConfigName("default")
err := viper.MergeInConfig()
```
which caches file path resolvemenet in `v.configFile`

and then
```
viper.SetConfigName("prod")
err := viper.MergeInConfig()
```

which reuses `v.configFile` without updating it accordingly to the new name.

See https://github.com/spf13/viper/blob/c1ccc378a054ea8d4e38d8c67f6938d4760b53dd/viper.go#L1240