### PR TITLE
Issue-105 Support time.Duration in viper.Unmarshal

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -611,7 +611,19 @@ func (v *Viper) UnmarshalKey(key string, rawVal interface{}) error {
 // on the fields of the structure are properly set.
 func Unmarshal(rawVal interface{}) error { return v.Unmarshal(rawVal) }
 func (v *Viper) Unmarshal(rawVal interface{}) error {
-	err := mapstructure.WeakDecode(v.AllSettings(), rawVal)
+	config := &mapstructure.DecoderConfig{
+		Metadata:         nil,
+		Result:           rawVal,
+		WeaklyTypedInput: true,
+		DecodeHook:       mapstructure.StringToTimeDurationHookFunc(),
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return err
+	}
+
+	err = decoder.Decode(v.AllSettings())
 
 	if err != nil {
 		return err

--- a/viper_test.go
+++ b/viper_test.go
@@ -453,10 +453,12 @@ func TestRecursiveAliases(t *testing.T) {
 func TestUnmarshal(t *testing.T) {
 	SetDefault("port", 1313)
 	Set("name", "Steve")
+	Set("duration", "1s1ms")
 
 	type config struct {
-		Port int
-		Name string
+		Port     int
+		Name     string
+		Duration time.Duration
 	}
 
 	var C config
@@ -466,14 +468,14 @@ func TestUnmarshal(t *testing.T) {
 		t.Fatalf("unable to decode into struct, %v", err)
 	}
 
-	assert.Equal(t, &C, &config{Name: "Steve", Port: 1313})
+	assert.Equal(t, &C, &config{Name: "Steve", Port: 1313, Duration: time.Second + time.Millisecond})
 
 	Set("port", 1234)
 	err = Unmarshal(&C)
 	if err != nil {
 		t.Fatalf("unable to decode into struct, %v", err)
 	}
-	assert.Equal(t, &C, &config{Name: "Steve", Port: 1234})
+	assert.Equal(t, &C, &config{Name: "Steve", Port: 1234, Duration: time.Second + time.Millisecond})
 }
 
 func TestBindPFlags(t *testing.T) {


### PR DESCRIPTION
Just add DecodeHook to DecoderConfig.
Allows to unmarshal into struct with time.Duration fields:
```
package main

import (
	"bytes"
	"fmt"
	"github.com/spf13/viper"
	"time"
)

type Config struct {
	Timeout time.Duration
	String  string
}

func main() {
	var cfg Config

	viper.SetConfigType("yaml")

	var yamlExample = []byte(`
Timeout: 200ms
String: it works!
`)

	viper.ReadConfig(bytes.NewBuffer(yamlExample))
	viper.Unmarshal(&cfg)

	// {Timeout:200ms String:it works!}
	fmt.Printf("%+v\n", cfg)
}
```