### PR TITLE
Optional TOML Support (disabled by default)

### DIFF
--- a/util.go
+++ b/util.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/BurntSushi/toml"
 	"github.com/hashicorp/hcl"
 	"github.com/magiconair/properties"
 	"github.com/spf13/cast"
@@ -155,7 +154,7 @@ func unmarshallConfigReader(in io.Reader, c map[string]interface{}, configType s
 		}
 
 	case "toml":
-		if _, err := toml.Decode(buf.String(), &c); err != nil {
+		if err := unmarshalTOML(buf.String(), &c); err != nil {
 			return ConfigParseError{err}
 		}
 

--- a/util_notoml.go
+++ b/util_notoml.go
@@ -1,0 +1,17 @@
+// +build !toml
+
+// Copyright © 2014 Steve Francia <spf@spf13.com>.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+// Viper is a application configuration system.
+// It believes that applications can be configured a variety of ways
+// via flags, ENVIRONMENT variables, configuration files retrieved
+// from the file system, or a remote key/value store.
+
+package viper
+
+func unmarshalTOML(data string, v interface{}) error {
+	return nil
+}

--- a/util_toml.go
+++ b/util_toml.go
@@ -1,0 +1,24 @@
+// +build toml
+
+// Copyright © 2014 Steve Francia <spf@spf13.com>.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+// Viper is a application configuration system.
+// It believes that applications can be configured a variety of ways
+// via flags, ENVIRONMENT variables, configuration files retrieved
+// from the file system, or a remote key/value store.
+
+package viper
+
+import (
+	"github.com/BurntSushi/toml"
+)
+
+func unmarshalTOML(data string, v interface{}) error {
+	if _, err := toml.Decode(data, v); err != nil {
+		return err
+	}
+	return nil
+}

--- a/viper_notoml_test.go
+++ b/viper_notoml_test.go
@@ -1,0 +1,32 @@
+// +build !toml
+
+// Copyright © 2014 Steve Francia <spf@spf13.com>.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package viper
+
+import (
+	"testing"
+	"time"
+)
+
+func initTOML(reset bool) {
+
+	if reset {
+		Reset()
+	}
+
+	v.config["title"] = "TOML Example"
+
+	dob, _ := time.Parse(time.RFC3339, "1979-05-27T07:32:00Z")
+	v.config["owner"] = map[string]interface{}{
+		"organization": "MongoDB",
+		"Bio":          "MongoDB Chief Developer Advocate & Hacker at Large",
+		"dob":          dob,
+	}
+}
+
+func assertConfigValue(t *testing.T, v *Viper) {
+}

--- a/viper_test.go
+++ b/viper_test.go
@@ -45,14 +45,6 @@ type testUnmarshalExtra struct {
 	Existing bool
 }
 
-var tomlExample = []byte(`
-title = "TOML Example"
-
-[owner]
-organization = "MongoDB"
-Bio = "MongoDB Chief Developer Advocate & Hacker at Large"
-dob = 1979-05-27T07:32:00Z # First class dates? Why not?`)
-
 var jsonExample = []byte(`{
 "id": "0001",
 "type": "donut",
@@ -120,9 +112,7 @@ func initConfigs() {
 	r = bytes.NewReader(propertiesExample)
 	unmarshalReader(r, v.config)
 
-	SetConfigType("toml")
-	r = bytes.NewReader(tomlExample)
-	unmarshalReader(r, v.config)
+	initTOML(false)
 
 	SetConfigType("json")
 	remote := bytes.NewReader(remoteExample)
@@ -149,14 +139,6 @@ func initProperties() {
 	Reset()
 	SetConfigType("properties")
 	r := bytes.NewReader(propertiesExample)
-
-	unmarshalReader(r, v.config)
-}
-
-func initTOML() {
-	Reset()
-	SetConfigType("toml")
-	r := bytes.NewReader(tomlExample)
 
 	unmarshalReader(r, v.config)
 }
@@ -318,7 +300,7 @@ func TestProperties(t *testing.T) {
 }
 
 func TestTOML(t *testing.T) {
-	initTOML()
+	initTOML(true)
 	assert.Equal(t, "TOML Example", Get("title"))
 }
 
@@ -722,7 +704,7 @@ func TestDirsSearch(t *testing.T) {
 	err = v.ReadInConfig()
 	assert.Nil(t, err)
 
-	assert.Equal(t, `value is `+path.Base(v.configPaths[0]), v.GetString(`key`))
+	assertConfigValue(t, v)
 }
 
 func TestWrongDirsSearchNotFound(t *testing.T) {

--- a/viper_toml_test.go
+++ b/viper_toml_test.go
@@ -1,0 +1,37 @@
+// +build toml
+
+// Copyright © 2014 Steve Francia <spf@spf13.com>.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package viper
+
+import (
+	"bytes"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var tomlExample = []byte(`
+title = "TOML Example"
+
+[owner]
+organization = "MongoDB"
+Bio = "MongoDB Chief Developer Advocate & Hacker at Large"
+dob = 1979-05-27T07:32:00Z # First class dates? Why not?`)
+
+func initTOML(reset bool) {
+	if reset {
+		Reset()
+	}
+	SetConfigType("toml")
+	r := bytes.NewReader(tomlExample)
+	unmarshalReader(r, v.config)
+}
+
+func assertConfigValue(t *testing.T, v *Viper) {
+	assert.Equal(t, `value is `+path.Base(v.configPaths[0]), v.GetString(`key`))
+}


### PR DESCRIPTION
This patch makes TOML support optional, disabling it by default. To enable support include the Golang build tag `toml`. For example, the following command builds Viper without TOML support:

```sh
$ go build
```

Whereas this command will build Viper, along with support for parsing TOML:

```sh
$ go build -tags toml
```

The reason for making TOML optional is due to the dependency upon the BurntSushi package that is used to unmarshal TOML content. The package is licensed under the [WTFPL license](http://www.wtfpl.net/) and incompatible with the Kubernetes project. Pull requests submitted to K8 that transitively include a dependency upon packages licensed under the WTFPL license [are denied](https://github.com/kubernetes/kubernetes/pull/28599#discussion_r71100997). The reason given links to [this discussion](https://news.ycombinator.com/item?id=5733050).

To this end, until such time an alternative package is deemed acceptable for parsing TOML content, this patch would make TOML an optional component of Viper, enabled only when explicitly requested via the build tag `toml`.

To prove no TOML is present, from the root of the branch execute:

```bash
$ go list -f '{{join .Deps "\n"}}' | grep toml
```

No matching packages are found. Using the build tag `toml` will reintroduce the now optional component:

```bash
$ go list -tags toml -f '{{join .Deps "\n"}}' | grep toml
github.com/BurntSushi/toml
```