### PR TITLE
replace SetEnvReplacer by SetEnvKeyReplacer

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ with ENV:
  * `AutomaticEnv()`
  * `BindEnv(string...) : error`
  * `SetEnvPrefix(string)`
- * `SetEnvReplacer(string...) *strings.Replacer`
+ * `SetEnvKeyReplacer(string...) *strings.Replacer`
 
 _When working with ENV variables, it’s important to recognize that Viper
 treats ENV variables as case sensitive._
@@ -211,7 +211,7 @@ time a `viper.Get` request is made. It will apply the following rules. It will
 check for a environment variable with a name matching the key uppercased and
 prefixed with the `EnvPrefix` if set.
 
-`SetEnvReplacer` allows you to use a `strings.Replacer` object to rewrite Env
+`SetEnvKeyReplacer` allows you to use a `strings.Replacer` object to rewrite Env
 keys to an extent. This is useful if you want to use `-` or something in your
 `Get()` calls, but want your environmental variables to use `_` delimiters. An
 example of using it can be found in `viper_test.go`.


### PR DESCRIPTION
It may be a typo: There is no SetEnvReplacer in viper.go but a SetEnvKeyReplacer function that match the description in README.md
