### PR TITLE
TOML Library Licensing

### DIFF
--- a/util.go
+++ b/util.go
@@ -21,9 +21,9 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/BurntSushi/toml"
 	"github.com/hashicorp/hcl"
 	"github.com/magiconair/properties"
+	toml "github.com/pelletier/go-toml"
 	"github.com/spf13/cast"
 	jww "github.com/spf13/jwalterweatherman"
 	"gopkg.in/yaml.v2"
@@ -155,8 +155,13 @@ func unmarshallConfigReader(in io.Reader, c map[string]interface{}, configType s
 		}
 
 	case "toml":
-		if _, err := toml.Decode(buf.String(), &c); err != nil {
+		tree, err := toml.LoadReader(buf)
+		if err != nil {
 			return ConfigParseError{err}
+		}
+		tmap := tree.ToMap()
+		for k, v := range tmap {
+			c[k] = v
 		}
 
 	case "properties", "props", "prop":


### PR DESCRIPTION
This patch updates the package used for parsing TOML content from `github.com/BurntSushi/toml` to `github.com/pelletier/go-toml` as the latter uses a more accepted OSS license (MIT), enabling the inclusion of Viper or projects that depend on Viper in projects that have licensing requirements incongruent with the license of the previous TOML package.

This patch replaces the PR #208 after discussing the matter with @spf13 and deciding to update the TOML parser instead of making TOML build-optional.