### PR TITLE
Throw a ConfigFileNotFoundError in certain cases

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -926,6 +926,9 @@ func (v *Viper) Set(key string, value interface{}) {
 func ReadInConfig() error { return v.ReadInConfig() }
 func (v *Viper) ReadInConfig() error {
 	jww.INFO.Println("Attempting to read in config file")
+	if v.getConfigFile() == "" {
+		return ConfigFileNotFoundError{v.configName, fmt.Sprintf("%s", v.configPaths)}
+	}
 	if !stringInSlice(v.getConfigType(), SupportedExts) {
 		return UnsupportedConfigError(v.getConfigType())
 	}

--- a/viper_test.go
+++ b/viper_test.go
@@ -738,7 +738,7 @@ func TestWrongDirsSearchNotFound(t *testing.T) {
 	v.AddConfigPath(`thispathaintthere`)
 
 	err := v.ReadInConfig()
-	assert.Equal(t, reflect.TypeOf(UnsupportedConfigError("")), reflect.TypeOf(err))
+	assert.Equal(t, reflect.TypeOf(ConfigFileNotFoundError{}), reflect.TypeOf(err))
 
 	// Even though config did not load and the error might have
 	// been ignored by the client, the default still loads

--- a/viper_test.go
+++ b/viper_test.go
@@ -200,6 +200,10 @@ func initDirs(t *testing.T) (string, string, func()) {
 			path.Join(dir, config+".toml"),
 			[]byte("key = \"value is "+dir+"\"\n"),
 			0640)
+		err = ioutil.WriteFile(
+			path.Join(dir, config+".notsupported"),
+			[]byte("key = \"value is"+dir+"\"\n"),
+			0640)
 		assert.Nil(t, err)
 	}
 
@@ -723,6 +727,24 @@ func TestDirsSearch(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, `value is `+path.Base(v.configPaths[0]), v.GetString(`key`))
+}
+
+func TestUnsupportedConfigFileType(t *testing.T) {
+	root, config, cleanup := initDirs(t)
+	defer cleanup()
+
+	v := New()
+	v.SetConfigName(config)
+	v.SetConfigType("notsupported")
+	entries, err := ioutil.ReadDir(root)
+	for _, e := range entries {
+		if e.IsDir() {
+			v.AddConfigPath(e.Name())
+		}
+	}
+	err = v.ReadInConfig()
+
+	assert.Equal(t, reflect.TypeOf(UnsupportedConfigError("")), reflect.TypeOf(err))
 }
 
 func TestWrongDirsSearchNotFound(t *testing.T) {


### PR DESCRIPTION
When the config file isn't found, it would be useful to see the paths
that viper is searching.  As it is now, the UnsupportedConfigError is
thrown when the file isn't found, and doesn't return useful information.

I also added an additional test for the UnsupportedConfigError, as it wasn't covered after my change.