### PR TITLE
Add Hugo CI Step to Validate Viper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
+go_import_path: github.com/spf13/viper
+
 language: go
 go:
   - 1.5.4
   - 1.6.3
   - 1.7
   - tip
-  
+
 os:
   - linux
   - osx
@@ -15,5 +17,11 @@ matrix:
   fast_finish: true
 
 script:
+  - go install ./...
   - go test -v ./...
+
+after_success:
+  - go get -u -d github.com/spf13/hugo
+  - cd $GOPATH/src/github.com/spf13/hugo && make && ./hugo -s docs && cd -
+
 sudo: false


### PR DESCRIPTION
Since Hugo is such a heavy user of Viper, this patch adds an `after_success` section to the Travis-CI build in order to validate the Viper commit by attempting to build Hugo and executing `hugo -s docs`.

This patch handles issue #222 and is in response to the need for additional testing discovered due to PRs #217 and #228.