### PR TITLE
Remove expensive TRACE logging in find

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ _testmain.go
 
 *.exe
 *.test
+*.bench

--- a/viper.go
+++ b/viper.go
@@ -463,12 +463,11 @@ func GetViper() *Viper {
 // Get returns an interface. For a specific value use one of the Get____ methods.
 func Get(key string) interface{} { return v.Get(key) }
 func (v *Viper) Get(key string) interface{} {
-	path := strings.Split(key, v.keyDelim)
-
 	lcaseKey := strings.ToLower(key)
 	val := v.find(lcaseKey)
 
 	if val == nil {
+		path := strings.Split(key, v.keyDelim)
 		source := v.find(strings.ToLower(path[0]))
 		if source != nil {
 			if reflect.TypeOf(source).Kind() == reflect.Map {
@@ -755,7 +754,6 @@ func (v *Viper) find(key string) interface{} {
 	// PFlag Override first
 	flag, exists := v.pflags[key]
 	if exists && flag.HasChanged() {
-		jww.TRACE.Printf("%q found in pflag override (%s): %s", key, flag.ValueType(), flag.ValueString())
 		switch flag.ValueType() {
 		case "int", "int8", "int16", "int32", "int64":
 			return cast.ToInt(flag.ValueString())
@@ -771,7 +769,6 @@ func (v *Viper) find(key string) interface{} {
 
 	val, exists = v.override[key]
 	if exists {
-		jww.TRACE.Printf("%q found in override: %s", key, val)
 		return val
 	}
 
@@ -779,24 +776,19 @@ func (v *Viper) find(key string) interface{} {
 		// even if it hasn't been registered, if automaticEnv is used,
 		// check any Get request
 		if val = v.getEnv(v.mergeWithEnvPrefix(key)); val != "" {
-			jww.TRACE.Printf("%q found in environment: %s", key, val)
 			return val
 		}
 	}
 
 	envkey, exists := v.env[key]
 	if exists {
-		jww.TRACE.Printf("%q registered as env var %q", key, envkey)
 		if val = v.getEnv(envkey); val != "" {
-			jww.TRACE.Printf("%q found in environment: %s", envkey, val)
 			return val
 		}
-		jww.TRACE.Printf("%q env value unset", envkey)
 	}
 
 	val, exists = v.config[key]
 	if exists {
-		jww.TRACE.Printf("%q found in config (%T): %s", key, val, val)
 		return val
 	}
 
@@ -809,7 +801,6 @@ func (v *Viper) find(key string) interface{} {
 			if reflect.TypeOf(source).Kind() == reflect.Map {
 				val := v.searchMap(cast.ToStringMap(source), path[1:])
 				if val != nil {
-					jww.TRACE.Printf("%q found in nested config: %s", key, val)
 					return val
 				}
 			}
@@ -818,13 +809,11 @@ func (v *Viper) find(key string) interface{} {
 
 	val, exists = v.kvstore[key]
 	if exists {
-		jww.TRACE.Printf("%q found in key/value store: %s", key, val)
 		return val
 	}
 
 	val, exists = v.defaults[key]
 	if exists {
-		jww.TRACE.Printf("%q found in defaults: ", key, val)
 		return val
 	}
 

--- a/viper_test.go
+++ b/viper_test.go
@@ -919,6 +919,18 @@ func TestShadowedNestedValue(t *testing.T) {
 	assert.Equal(t, GetString("clothing.shirt"), polyester)
 }
 
+func TestGetBool(t *testing.T) {
+	key := "BooleanKey"
+	v = New()
+	v.Set(key, true)
+	if !v.GetBool(key) {
+		t.Fatal("GetBool returned false")
+	}
+	if v.GetBool("NotFound") {
+		t.Fatal("GetBool returned true")
+	}
+}
+
 func BenchmarkGetBool(b *testing.B) {
 	key := "BenchmarkGetBool"
 	v = New()


### PR DESCRIPTION
Also avoid doing a strings.Split in the Get common case.

Any TRACE statements in these hot paths must be totally turned off when not testing.

```
benchmark                     old ns/op     new ns/op     delta
BenchmarkGetBool-4            4090          409           -90.00%
BenchmarkGetBoolFromMap-4     6.33          6.28          -0.79%

benchmark                     old allocs     new allocs     delta
BenchmarkGetBool-4            6              3              -50.00%
BenchmarkGetBoolFromMap-4     0              0              +0.00%

benchmark                     old bytes     new bytes     delta
BenchmarkGetBool-4            129           33            -74.42%
BenchmarkGetBoolFromMap-4     0             0             +0.00%
```

Fixes #242