### PR TITLE
Fixed AllKeys() to include env values added with BindEnv()

### DIFF
--- a/viper_test.go
+++ b/viper_test.go
@@ -445,6 +445,23 @@ func TestAllKeys(t *testing.T) {
 	assert.Equal(t, all, AllSettings())
 }
 
+func TestAllKeysWithEnv(t *testing.T) {
+	v := New()
+
+	// bind and define environment variables (including a nested one)
+	v.BindEnv("id")
+	v.BindEnv("foo.bar")
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	os.Setenv("ID", "13")
+	os.Setenv("FOO_BAR", "baz")
+
+	expectedKeys := sort.StringSlice{"id", "foo.bar"}
+	expectedKeys.Sort()
+	keys := sort.StringSlice(v.AllKeys())
+	keys.Sort()
+	assert.Equal(t, expectedKeys, keys)
+}
+
 func TestAliasesOfAliases(t *testing.T) {
 	Set("Title", "Checking Case")
 	RegisterAlias("Foo", "Bar")


### PR DESCRIPTION
Bug fixed in `AllKeys()` by doing an explicit cast of `v.env` to a `map[string]interface{}`.

This will in turn repair `AllSettings()` and `Unmarshal()`, which also ignored environment values added manually.

Fixes issue raised in [this comment](https://github.com/spf13/viper/pull/195#issuecomment-255517435) in PR #195, and mentioned at the end of Issue #188.
