### PR TITLE
Add more intricate TypeByDefaultValue logic

### DIFF
--- a/viper_test.go
+++ b/viper_test.go
@@ -789,6 +789,67 @@ func TestSub(t *testing.T) {
 	assert.Equal(t, (*Viper)(nil), subv)
 }
 
+var yamlTypeExample = []byte(`
+hobbies:
+- skateboarding
+- snowboarding
+languages: go golang python
+job:
+  salary: 100,000 USD
+  medical: full
+clothes:
+- jacket: leather
+  trousers: denim
+  pants:
+    size: large
+- jacket: denim
+  trousers: slacks
+  pants:
+    size: medium
+`)
+
+type Clothing struct {
+	Jacket   string
+	Trousers string
+	Pants    Pants
+}
+
+type Pants struct {
+	Size string
+}
+
+type Job struct {
+	Salary  string
+	Medical string
+}
+
+func TestTypeByDefaultValue(t *testing.T) {
+	v := New()
+	v.SetConfigType("yaml")
+	v.SetDefault("hobbies", []string{})
+	v.SetDefault("languages", []string{})
+	v.SetDefault("job", &Job{})
+	v.SetDefault("clothes", []Clothing{})
+	v.SetTypeByDefaultValue(true)
+	err := v.ReadConfig(bytes.NewBuffer(yamlTypeExample))
+	assert.NoError(t, err)
+
+	assert.Equal(t, []string{"skateboarding", "snowboarding"}, v.Get("hobbies"))
+	assert.Equal(t, []string{"go", "golang", "python"}, v.Get("languages"))
+	assert.Equal(t, []Clothing{
+		{
+			Jacket:   "leather",
+			Trousers: "denim",
+			Pants:    Pants{Size: "large"},
+		},
+		{
+			Jacket:   "denim",
+			Trousers: "slacks",
+			Pants:    Pants{Size: "medium"},
+		},
+	}, v.Get("clothes"))
+}
+
 var yamlMergeExampleTgt = []byte(`
 hello:
     pop: 37890


### PR DESCRIPTION
The current documentation for `SetTypeByDefaultValue` suggests that I can set a default value and I will always be returned data for this key that is of that type.  The following code is similar to something I wrote based on that documentation before finding out that it actually ends up causing a panic:

```go
type Project struct {
    Name string
    Path string
    Gopath string
}

func init() {
    projects = viper.New()
    projects.SetTypeByDefaultValue(true)
    projects.SetDefault("projects", []Project{})
}

func Projects() []Project {
    return projects.Get("projects").([]Project)
}
```

This PR supports the above example, in addition to adding some tests for the prior code.  The solution is a bit naive, but I wanted to get feedback early on whether or not this is a feature that would be accepted.  If so, I think I'd need to at least fix up some of the panics in the code (specifically, anywhere `someVal.Set(convert(someOtherVal, typ))` is called - the current `convert` code falls back to returning the raw original value if it can't successfully convert, which will cause `someVal.Set` to panic).

A question for maintainers: what would be the correct thing to do when the data cannot be converted to the type of the default value?  I'm inclined to fall back to prior behavior (returning the raw data in `map[string]interface{}`, `[]interface{}`, `string`, or whatever format - just let the calling code complain if the data is wrong), but I think it's worth a discussion.