### PR TITLE
Add top level key support

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/deckarep/golang-set"
 	"github.com/fsnotify/fsnotify"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/afero"
@@ -1334,6 +1335,32 @@ func (v *Viper) AllKeys() []string {
 		a = append(a, x)
 	}
 	return a
+}
+
+// Get the set of all top level keys.
+func TopLevelKeys() []string { return v.TopLevelKeys() }
+func (v *Viper) TopLevelKeys() []string {
+	s := mapset.NewSetFromSlice(v.getMapKeys(castMapStringToMapInterface(v.aliases)))
+	s = s.Union(mapset.NewSetFromSlice(v.getMapKeys(v.override)))
+	s = s.Union(mapset.NewSetFromSlice(v.getMapKeys(castMapFlagToMapInterface(v.pflags))))
+	s = s.Union(mapset.NewSetFromSlice(v.getMapKeys(castMapStringToMapInterface(v.env))))
+	s = s.Union(mapset.NewSetFromSlice(v.getMapKeys(v.config)))
+	s = s.Union(mapset.NewSetFromSlice(v.getMapKeys(v.defaults)))
+
+	// convert interface{} to string
+	keys := []string{}
+	for _, k := range s.ToSlice() {
+		keys = append(keys, k.(string))
+	}
+	return keys
+}
+
+func (v *Viper) getMapKeys(m map[string]interface{}) []interface{} {
+	keys := []interface{}{}
+	for key := range m {
+		keys = append(keys, key)
+	}
+	return keys
 }
 
 // flattenAndMergeMap recursively flattens the given map into a map[string]bool


### PR DESCRIPTION
Would be really nice to be able to get the top-level keys for a configuration so it is easier to iterate through a group of settings.

Here's an example.

Config file:

    ---
    my:
        settings:
            group:
                a:
                    one: thingone
                    two: thingtwo
                b:
                    one: anotherthingone
                    two: anotherthingtwo

Code:

    v := viper.Sub("my.settings.group")
    for _, i := range v.TopLevelKeys() {
        vv := v.Sub(i)
        for _, j := range vv.AllKeys() {
            // do something with this set of keys
        }
    }