### PR TITLE
Expose configPaths via ConfigPaths() and v.ConfigPaths()

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1416,6 +1416,10 @@ func (v *Viper) AllSettings() map[string]interface{} {
 	return m
 }
 
+// ConfigPaths returns all config paths that Viper searches for config files in.
+func ConfigPaths() []string { return v.configPaths }
+func (v *Viper) ConfigPaths() []string { return v.configPaths }
+
 // SetFs sets the filesystem to use to read configuration.
 func SetFs(fs afero.Fs) { v.SetFs(fs) }
 func (v *Viper) SetFs(fs afero.Fs) {


### PR DESCRIPTION
Managed a slice by myself for a few projects, then looping over and adding with
`AddConfigPath()` to be able to log the locations got boring, would like `viper`
to just do this for me.

A motivating example is that I want to display the searched locations as a part of preflight
logging in applications, e.g:

```bash
: ~/v $; go run main.go
WARN[0000] preflight complete                            config= locations=[/Users/thorduri/v /Users/thorduri/v/etc]
run!
: ~/v $; touch etc/config.yaml
: ~/v $; go run main.go
INFO[0000] preflight complete                            config="/Users/thorduri/v/etc/config.yaml" locations=[/Users/thorduri/v /Users/thorduri/v/etc]
run!
: ~/v $; go run main.go -c config.yaml
Error: open config.yaml: no such file or directory
...
```

See [main.go](https://gist.github.com/thorduri/cd90608685352c0b619a05d0c8941451) for a somewhat contrived, but realistic (my boilerplate looks pretty much like that) example.