### PR TITLE
Fix MergeInConfig error return

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1102,13 +1102,13 @@ func (v *Viper) ReadInConfig() error {
 func MergeInConfig() error { return v.MergeInConfig() }
 func (v *Viper) MergeInConfig() error {
 	jww.INFO.Println("Attempting to merge in config file")
-	if !stringInSlice(v.getConfigType(), SupportedExts) {
-		return UnsupportedConfigError(v.getConfigType())
-	}
-
 	filename, err := v.getConfigFile()
 	if err != nil {
 		return err
+	}
+
+	if !stringInSlice(v.getConfigType(), SupportedExts) {
+		return UnsupportedConfigError(v.getConfigType())
 	}
 
 	file, err := afero.ReadFile(v.fs, filename)

--- a/viper_test.go
+++ b/viper_test.go
@@ -771,6 +771,26 @@ func TestWrongDirsSearchNotFound(t *testing.T) {
 	assert.Equal(t, `default`, v.GetString(`key`))
 }
 
+func TestWrongDirsSearchNotFoundForMerge(t *testing.T) {
+
+	_, config, cleanup := initDirs(t)
+	defer cleanup()
+
+	v := New()
+	v.SetConfigName(config)
+	v.SetDefault(`key`, `default`)
+
+	v.AddConfigPath(`whattayoutalkingbout`)
+	v.AddConfigPath(`thispathaintthere`)
+
+	err := v.MergeInConfig()
+	assert.Equal(t, reflect.TypeOf(ConfigFileNotFoundError{"", ""}), reflect.TypeOf(err))
+
+	// Even though config did not load and the error might have
+	// been ignored by the client, the default still loads
+	assert.Equal(t, `default`, v.GetString(`key`))
+}
+
 func TestSub(t *testing.T) {
 	v := New()
 	v.SetConfigType("yaml")


### PR DESCRIPTION
* **Fixed**: UnsupportedConfigError is returned if config file is not found
Swap getConfigFile and getConfigType call
Add a unit test