### PR TITLE
[WIP] Add write methods

### DIFF
--- a/util.go
+++ b/util.go
@@ -164,31 +164,37 @@ func userHomeDir() string {
 	return os.Getenv("HOME")
 }
 
-func marshalConfigWriter(out afero.File, c map[string]interface{}, configType string) error {
+func marshalConfigWriter(f afero.File, c map[string]interface{}, configType string) error {
 	switch configType {
 	case "json":
 		b, err := json.MarshalIndent(v.AllSettings(), "", "    ")
 		if err != nil {
 			return ConfigMarshalError{err}
 		}
-		_, err = out.WriteString(string(b))
+		_, err = f.WriteString(string(b))
 		if err != nil {
 			return ConfigMarshalError{err}
 		}
 
-	// case "toml":
-	// 	w := bufio.NewWriter(out)
-	// 	if err := toml.NewEncoder(w).Encode(v.AllSettings()); err != nil {
-	// 		return ConfigMarshalError{err}
-	// 	}
-	// 	w.Flush()
+	case "hcl":
+		// TODO: How to convert map to hcl???
+
+	case "prop", "props", "properties":
+
+	case "toml":
+		t := toml.TreeFromMap(v.AllSettings())
+		s := t.String()
+		_, err := f.WriteString(s)
+		if err != nil {
+			return ConfigMarshalError{err}
+		}
 
 	case "yaml", "yml":
 		b, err := yaml.Marshal(v.AllSettings())
 		if err != nil {
 			return ConfigMarshalError{err}
 		}
-		_, err = out.WriteString(string(b))
+		_, err = f.WriteString(string(b))
 		if err != nil {
 			return ConfigMarshalError{err}
 		}

--- a/viper.go
+++ b/viper.go
@@ -36,7 +36,6 @@ import (
 	jww "github.com/spf13/jwalterweatherman"
 	"github.com/spf13/pflag"
 	"gopkg.in/fsnotify.v1"
-	"gopkg.in/yaml.v2"
 )
 
 var v *Viper


### PR DESCRIPTION
This PR is a work in progress. It is based on earlier code submitted by @g3rk6 in spf13/viper#153. I am working through satisfying the requests in @spf13's comments.

It adds methods to write the configuration back to the file or to a new file. There are methods to do so only if the file does not exist.

The two things stopping this from being done are:
- I cannot determine how to encode the map to hcl. I'm sure there is a way, but I have not worked it out yet. I think it will have to be printed to a writer. It would be nice if there was a map to string method. If anybody has a good idea, let me know.
- I have not written any tests yet. That may take a few.

After this is done, I also intend to add methods to write specific values in the map to file. In that case, you don't have to worry about adding unwanted values like env variables to the file.