### PR TITLE
Only save config on success in ReadInConfig

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1093,9 +1093,15 @@ func (v *Viper) ReadInConfig() error {
 		return err
 	}
 
-	v.config = make(map[string]interface{})
+	config := make(map[string]interface{})
 
-	return v.unmarshalReader(bytes.NewReader(file), v.config)
+	err = v.unmarshalReader(bytes.NewReader(file), config)
+	if err != nil {
+		return err
+	}
+
+	v.config = config
+	return nil
 }
 
 // MergeInConfig merges a new configuration with an existing config.


### PR DESCRIPTION
If the user creates a invalid config file while watching for config
changes, the previous, valid config is not retained.  This commit only
overwrites the running config if unmarshalling was successful.

Updates spf13/hugo#2603