### PR TITLE
Fix UnmarshalKey handling of time.Duration

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -713,7 +713,15 @@ func (v *Viper) GetSizeInBytes(key string) uint {
 // UnmarshalKey takes a single key and unmarshals it into a Struct.
 func UnmarshalKey(key string, rawVal interface{}) error { return v.UnmarshalKey(key, rawVal) }
 func (v *Viper) UnmarshalKey(key string, rawVal interface{}) error {
-	return mapstructure.Decode(v.Get(key), rawVal)
+	err := decode(v.Get(key), defaultDecoderConfig(rawVal))
+
+	if err != nil {
+		return err
+	}
+
+	v.insensitiviseMaps()
+
+	return nil
 }
 
 // Unmarshal unmarshals the config into a Struct. Make sure that the tags

--- a/viper_test.go
+++ b/viper_test.go
@@ -1102,6 +1102,35 @@ func TestCaseInsensitiveSet(t *testing.T) {
 	}
 }
 
+func TestParseNested(t *testing.T) {
+	type duration struct {
+		Delay time.Duration
+	}
+
+	type item struct {
+		Name   string
+		Delay  time.Duration
+		Nested duration
+	}
+
+	config := `[[parent]]
+	delay="100ms"
+	[parent.nested]
+	delay="200ms"
+`
+	initConfig("toml", config)
+
+	var items []item
+	err := v.UnmarshalKey("parent", &items)
+	if err != nil {
+		t.Fatalf("unable to decode into struct, %v", err)
+	}
+
+	assert.Equal(t, 1, len(items))
+	assert.Equal(t, 100*time.Millisecond, items[0].Delay)
+	assert.Equal(t, 200*time.Millisecond, items[0].Nested.Delay)
+}
+
 func doTestCaseInsensitive(t *testing.T, typ, config string) {
 	initConfig(typ, config)
 	Set("RfD", true)


### PR DESCRIPTION
The use case arose when using UnmarshalKey on structs that contain nested structs that contain a time.Duration it would throw a message like:

`* '[0].Nested.Delay' expected type 'time.Duration', got unconvertible type 'string'`

This PR fixes the handling of time.Duration objects and adds a test for it.