### PR TITLE
Avoid the start of go-routines which are never get stopped (Description Issue #312)

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -33,13 +33,12 @@ func (rc remoteConfigProvider) Watch(rp viper.RemoteProvider) (io.Reader, error)
 	if err != nil {
 		return nil, err
 	}
-	resp := <-cm.Watch(rp.Path(), nil)
-	err = resp.Error
+	resp,err := cm.Get(rp.Path())
 	if err != nil {
 		return nil, err
 	}
 
-	return bytes.NewReader(resp.Value), nil
+	return bytes.NewReader(resp), nil
 }
 
 func getConfigManager(rp viper.RemoteProvider) (crypt.ConfigManager, error) {

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -40,26 +40,13 @@ func (rc remoteConfigProvider) Watch(rp viper.RemoteProvider) (io.Reader, error)
 
 	return bytes.NewReader(resp), nil
 }
-func (rc remoteConfigProvider) WatchChannel(rp viper.RemoteProvider) (<-chan *viper.RemoteResponse, chan bool) {
+func (rc remoteConfigProvider) WatchChannel(rp viper.RemoteProvider) (<-chan *crypt.Response, chan bool) {
 	cm, err := getConfigManager(rp)
 	if err != nil {
 		return nil, nil
 	}
 	quit := make(chan bool)
-	respChan := make(chan *viper.RemoteResponse, 0)
-	watchchan := cm.Watch(rp.Path(), quit)
-	// Todo Add quit channel
-	go func(w <-chan *crypt.Response) {
-		for {
-			resp := <-w
-			respChan <- &viper.RemoteResponse{
-				Error: resp.Error,
-				Value: resp.Value,
-			}
-		}
-
-	 }(watchchan)
-	return respChan ,quit
+	return cm.Watch(rp.Path(), quit) ,quit
 
 }
 

--- a/viper.go
+++ b/viper.go
@@ -38,6 +38,11 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// Response represents a response from a backend store.
+type RemoteResponse struct {
+	Value []byte
+	Error error
+}
 var v *Viper
 
 func init() {
@@ -47,6 +52,7 @@ func init() {
 type remoteConfigFactory interface {
 	Get(rp RemoteProvider) (io.Reader, error)
 	Watch(rp RemoteProvider) (io.Reader, error)
+	WatchChannel(rp RemoteProvider)(<-chan *RemoteResponse, chan bool)
 }
 
 // RemoteConfig is optional, see the remote package
@@ -1255,6 +1261,10 @@ func (v *Viper) WatchRemoteConfig() error {
 	return v.watchKeyValueConfig()
 }
 
+func (v *Viper) WatchRemoteConfigOnChannel() error {
+	return v.watchKeyValueConfigOnChannel()
+}
+
 // Unmarshall a Reader into a map.
 // Should probably be an unexported function.
 func unmarshalReader(in io.Reader, c map[string]interface{}) error {
@@ -1296,6 +1306,23 @@ func (v *Viper) getRemoteConfig(provider RemoteProvider) (map[string]interface{}
 	}
 	err = v.unmarshalReader(reader, v.kvstore)
 	return v.kvstore, err
+}
+
+// Retrieve the first found remote configuration.
+func (v *Viper) watchKeyValueConfigOnChannel() error {
+	for _, rp := range v.remoteProviders {
+		respc, _ := RemoteConfig.WatchChannel(rp)
+		//Todo: Add quit channel
+		go func(rc <-chan *RemoteResponse) {
+			for {
+				b := <-rc
+				reader := bytes.NewReader(b.Value)
+				v.unmarshalReader(reader, v.kvstore)
+			}
+		}(respc)
+		return nil
+	}
+	return RemoteConfigError("No Files Found")
 }
 
 // Retrieve the first found remote configuration.

--- a/viper.go
+++ b/viper.go
@@ -36,13 +36,9 @@ import (
 	"github.com/spf13/cast"
 	jww "github.com/spf13/jwalterweatherman"
 	"github.com/spf13/pflag"
+	crypt "github.com/xordataexchange/crypt/config"
 )
 
-// Response represents a response from a backend store.
-type RemoteResponse struct {
-	Value []byte
-	Error error
-}
 var v *Viper
 
 func init() {
@@ -52,7 +48,7 @@ func init() {
 type remoteConfigFactory interface {
 	Get(rp RemoteProvider) (io.Reader, error)
 	Watch(rp RemoteProvider) (io.Reader, error)
-	WatchChannel(rp RemoteProvider)(<-chan *RemoteResponse, chan bool)
+	WatchChannel(rp RemoteProvider)(<-chan *crypt.Response, chan bool)
 }
 
 // RemoteConfig is optional, see the remote package
@@ -1313,7 +1309,7 @@ func (v *Viper) watchKeyValueConfigOnChannel() error {
 	for _, rp := range v.remoteProviders {
 		respc, _ := RemoteConfig.WatchChannel(rp)
 		//Todo: Add quit channel
-		go func(rc <-chan *RemoteResponse) {
+		go func(rc <-chan *crypt.Response) {
 			for {
 				b := <-rc
 				reader := bytes.NewReader(b.Value)


### PR DESCRIPTION
This fix would avoid that while using the RemoteWatch-feature go-routines are started which never get stopped what causing a mem-leak (described here)