### PR TITLE
Add GetIntSlice functions

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -684,6 +684,12 @@ func (v *Viper) GetStringSlice(key string) []string {
 	return cast.ToStringSlice(v.Get(key))
 }
 
+// GetIntSlice returns the value associated with the key as a slice of ints.
+func GetIntSlice(key string) []int { return v.GetIntSlice(key) }
+func (v *Viper) GetIntSlice(key string) []int {
+	return cast.ToIntSlice(v.Get(key))
+}
+
 // GetStringMap returns the value associated with the key as a map of interfaces.
 func GetStringMap(key string) map[string]interface{} { return v.GetStringMap(key) }
 func (v *Viper) GetStringMap(key string) map[string]interface{} {

--- a/viper_test.go
+++ b/viper_test.go
@@ -818,6 +818,10 @@ hello:
     - uk
     - fr
     - de
+    groups:
+    - 1
+    - 2
+    - 3
 `)
 
 var yamlMergeExampleSrc = []byte(`
@@ -827,6 +831,9 @@ hello:
     universe:
     - mw
     - ad
+    ages:
+    - 21
+    - 34
 fu: bar
 `)
 
@@ -851,6 +858,10 @@ func TestMergeConfig(t *testing.T) {
 
 	if world := v.GetStringSlice("hello.world"); len(world) != 4 {
 		t.Fatalf("len(world) != 4, = %d", len(world))
+	}
+
+	if groups := v.GetIntSlice("hello.groups"); len(groups) != 3 {
+		t.Fatalf("len(groups) != 3, = %d", len(groups))
 	}
 
 	if fu := v.GetString("fu"); fu != "" {
@@ -881,6 +892,14 @@ func TestMergeConfig(t *testing.T) {
 		t.Fatalf("len(universe) != 2, = %d", len(universe))
 	}
 
+	if groups := v.GetIntSlice("hello.groups"); len(groups) != 3 {
+		t.Fatalf("len(groups) != 3, = %d", len(groups))
+	}
+
+	if ages := v.GetIntSlice("hello.ages"); len(ages) != 2 {
+		t.Fatalf("len(ages) != 2, = %d", len(ages))
+	}
+
 	if fu := v.GetString("fu"); fu != "bar" {
 		t.Fatalf("fu != \"bar\", = %s", fu)
 	}
@@ -901,6 +920,10 @@ func TestMergeConfigNoMerge(t *testing.T) {
 		t.Fatalf("len(world) != 4, = %d", len(world))
 	}
 
+	if groups := v.GetIntSlice("hello.groups"); len(groups) != 3 {
+		t.Fatalf("len(groups) != 3, = %d", len(groups))
+	}
+
 	if fu := v.GetString("fu"); fu != "" {
 		t.Fatalf("fu != \"\", = %s", fu)
 	}
@@ -919,6 +942,14 @@ func TestMergeConfigNoMerge(t *testing.T) {
 
 	if universe := v.GetStringSlice("hello.universe"); len(universe) != 2 {
 		t.Fatalf("len(universe) != 2, = %d", len(universe))
+	}
+
+	if groups := v.GetIntSlice("hello.groups"); len(groups) != 0 {
+		t.Fatalf("len(groups) != 0, = %d", len(groups))
+	}
+
+	if ages := v.GetIntSlice("hello.ages"); len(ages) != 2 {
+		t.Fatalf("len(groups) != 2, = %d", len(ages))
 	}
 
 	if fu := v.GetString("fu"); fu != "bar" {


### PR DESCRIPTION
Example:

```go
package main

import (
	"bytes"
	"log"

	"github.com/spf13/viper"
)

func main() {
	cfg := []byte(`
groups:
  - 1
  - 10001
  - 1000001
`)
	viper.SetConfigType("yaml")
	if err := viper.ReadConfig(bytes.NewBuffer(cfg)); err != nil {
		panic(err)
	}
	groups := viper.GetIntSlice("groups")
	log.Printf("%+v len %d", groups, len(groups))
}
```

Output:

```bash
≻ go run main.go
2017/03/02 11:21:05 [1 10001 1000001] len 3
```