### PR TITLE
add new method configFileChain

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -145,11 +145,11 @@ type Viper struct {
 	remoteProviders []*defaultRemoteProvider
 
 	// Name of file to look for inside the path
-	configName  string
-	configFile  string
-	configFiles []string
-	configType  string
-	envPrefix   string
+	configName      string
+	configFile      string
+	configFileChain []string
+	configType      string
+	envPrefix       string
 
 	automaticEnvApplied bool
 	envKeyReplacer      *strings.Replacer
@@ -292,12 +292,12 @@ func (v *Viper) SetConfigFile(in string) {
 	}
 }
 
-// SetConfigFiles explicitly defines slice of the path, name and extension of the config files
+// SetConfigFileChain explicitly defines slice of the path, name and extension of the config files
 // Viper will use these and not check any of the config paths
-func SetConfigFiles(in []string) { v.SetConfigFiles(in) }
-func (v *Viper) SetConfigFiles(in []string) {
+func SetConfigChain(in []string) { v.SetConfigFileChain(in) }
+func (v *Viper) SetConfigFileChain(in []string) {
 	if len(in) > 0 {
-		v.configFiles = in
+		v.configFileChain = in
 	}
 }
 
@@ -1141,17 +1141,17 @@ func (v *Viper) MergeInConfig() error {
 	return v.MergeConfig(bytes.NewReader(file))
 }
 
-// ChainMergeConfigfiles repeatedly merge with configFiles
-func ChainMergeConfigFiles() error { return v.ChainMergeConfigFiles() }
-func (v *Viper) ChainMergeConfigFiles() error {
-	jww.INFO.Println("Attempting to chain merge with configFiles")
+// MergeConfigFileChain repeatedly merge with configFileChain
+func MergeConfigFileChain() error { return v.MergeConfigFileChain() }
+func (v *Viper) MergeConfigFileChain() error {
+	jww.INFO.Println("Attempting to chain merge with configFileChain")
 
-	configFiles, err := v.getConfigFiles()
+	configFileChain, err := v.getConfigFileChain()
 	if err != nil {
 		return err
 	}
 
-	for i, filename := range configFiles {
+	for i, filename := range configFileChain {
 		if i == 0 {
 			v.SetConfigFile(filename)
 			err := v.ReadInConfig()
@@ -1544,11 +1544,11 @@ func (v *Viper) getConfigFile() (string, error) {
 	return v.getConfigFile()
 }
 
-func (v *Viper) getConfigFiles() ([]string, error) {
+func (v *Viper) getConfigFileChain() ([]string, error) {
 	// if explicitly set, then use it
 	// else search config file and return as slice
-	if len(v.configFiles) > 0 {
-		return v.configFiles, nil
+	if len(v.configFileChain) > 0 {
+		return v.configFileChain, nil
 	}
 
 	cf, err := v.findConfigFile()
@@ -1556,8 +1556,8 @@ func (v *Viper) getConfigFiles() ([]string, error) {
 		return nil, err
 	}
 
-	v.configFiles = []string{cf}
-	return v.getConfigFiles()
+	v.configFileChain = []string{cf}
+	return v.getConfigFileChain()
 }
 
 func (v *Viper) searchInPath(in string) (filename string) {

--- a/viper.go
+++ b/viper.go
@@ -1146,7 +1146,12 @@ func ChainMergeConfigFiles() error { return v.ChainMergeConfigFiles() }
 func (v *Viper) ChainMergeConfigFiles() error {
 	jww.INFO.Println("Attempting to chain merge with configFiles")
 
-	for i, filename := range v.configFiles {
+	configFiles, err := v.getConfigFiles()
+	if err != nil {
+		return err
+	}
+
+	for i, filename := range configFiles {
 		if i == 0 {
 			v.SetConfigFile(filename)
 			err := v.ReadInConfig()
@@ -1537,6 +1542,22 @@ func (v *Viper) getConfigFile() (string, error) {
 
 	v.configFile = cf
 	return v.getConfigFile()
+}
+
+func (v *Viper) getConfigFiles() ([]string, error) {
+	// if explicitly set, then use it
+	// else search config file and return as slice
+	if len(v.configFiles) > 0 {
+		return v.configFiles, nil
+	}
+
+	cf, err := v.findConfigFile()
+	if err != nil {
+		return nil, err
+	}
+
+	v.configFiles = []string{cf}
+	return v.getConfigFiles()
 }
 
 func (v *Viper) searchInPath(in string) (filename string) {

--- a/viper_test.go
+++ b/viper_test.go
@@ -1193,7 +1193,7 @@ func initConfigsForMerge(t *testing.T) (string, string, func()) {
 	}
 }
 
-func TestChainMergeConfig(t *testing.T) {
+func TestMergeConfigChain(t *testing.T) {
 
 	root, config, cleanup := initConfigsForMerge(t)
 	defer cleanup()
@@ -1209,8 +1209,8 @@ func TestChainMergeConfig(t *testing.T) {
 			configfile := path.Join(root, e.Name(), config)
 			configfiles = append(configfiles, configfile)
 
-			v.SetConfigFiles(configfiles[:i+1])
-			err = v.ChainMergeConfigFiles()
+			v.SetConfigFileChain(configfiles[:i+1])
+			err = v.MergeConfigFileChain()
 			assert.Nil(t, err)
 			assert.Equal(t, `value is `+e.Name(), v.GetString(`key`))
 			assert.Equal(t, `a`, v.GetString(`a`))
@@ -1230,7 +1230,7 @@ func TestChainMergeConfig(t *testing.T) {
 	}
 }
 
-func TestNotSetConfigFilesChainMerge(t *testing.T) {
+func TestNotSetConfigFileChainMerge(t *testing.T) {
 	// If not set, behavior is identical to ReadInConfig
 
 	root, config, cleanup := initDirs(t)
@@ -1248,7 +1248,7 @@ func TestNotSetConfigFilesChainMerge(t *testing.T) {
 	}
 	assert.Nil(t, err)
 
-	err = v.ChainMergeConfigFiles()
+	err = v.MergeConfigFileChain()
 	assert.Nil(t, err)
 
 	assert.Equal(t, `value is `+path.Base(v.configPaths[0]), v.GetString(`key`))


### PR DESCRIPTION
Although `MergeInConfig` has quite important functionality, it is necessary to repeat `SetConfigFile` in order to apply to multiple config files.
This PR add to the wrapper function `MergeConfigFileChain` of `MergeInConfig` to make it cheaper to use.
- set slice of config files as `v.configFileChain` via `SetConfigFileChain`
- index of slice `v.confiFileChain` define the priority for merge config
  - larger number of index means higher priority (namely, merged later)

Actually, I would like to use this method for `hugo` considering https://github.com/spf13/hugo/issues/2735