### PR TITLE
adds test case for UnmarshalKey time.Duration

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -52,7 +52,7 @@ func init() {
 type remoteConfigFactory interface {
 	Get(rp RemoteProvider) (io.Reader, error)
 	Watch(rp RemoteProvider) (io.Reader, error)
-	WatchChannel(rp RemoteProvider)(<-chan *RemoteResponse, chan bool)
+	WatchChannel(rp RemoteProvider) (<-chan *RemoteResponse, chan bool)
 }
 
 // RemoteConfig is optional, see the remote package
@@ -719,7 +719,7 @@ func (v *Viper) GetSizeInBytes(key string) uint {
 // UnmarshalKey takes a single key and unmarshals it into a Struct.
 func UnmarshalKey(key string, rawVal interface{}) error { return v.UnmarshalKey(key, rawVal) }
 func (v *Viper) UnmarshalKey(key string, rawVal interface{}) error {
-	return mapstructure.Decode(v.Get(key), rawVal)
+	return decode(v.Get(key), defaultDecoderConfig(rawVal))
 }
 
 // Unmarshal unmarshals the config into a Struct. Make sure that the tags

--- a/viper_test.go
+++ b/viper_test.go
@@ -478,11 +478,17 @@ func TestUnmarshal(t *testing.T) {
 	SetDefault("port", 1313)
 	Set("name", "Steve")
 	Set("duration", "1s1ms")
+	Set("sub.duration", "10m")
+
+	type subConfig struct {
+		Duration time.Duration
+	}
 
 	type config struct {
 		Port     int
 		Name     string
 		Duration time.Duration
+		Sub      *subConfig
 	}
 
 	var C config
@@ -492,14 +498,18 @@ func TestUnmarshal(t *testing.T) {
 		t.Fatalf("unable to decode into struct, %v", err)
 	}
 
-	assert.Equal(t, &config{Name: "Steve", Port: 1313, Duration: time.Second + time.Millisecond}, &C)
+	assert.Equal(t, &config{Name: "Steve", Port: 1313, Duration: time.Second + time.Millisecond, Sub: &subConfig{Duration: time.Minute * 10}}, &C)
 
 	Set("port", 1234)
 	err = Unmarshal(&C)
 	if err != nil {
 		t.Fatalf("unable to decode into struct, %v", err)
 	}
-	assert.Equal(t, &config{Name: "Steve", Port: 1234, Duration: time.Second + time.Millisecond}, &C)
+	assert.Equal(t, &config{Name: "Steve", Port: 1234, Duration: time.Second + time.Millisecond, Sub: &subConfig{Duration: time.Minute * 10}}, &C)
+
+	sub := &subConfig{}
+	assert.NoError(t, UnmarshalKey("sub", sub))
+
 }
 
 func TestBindPFlags(t *testing.T) {


### PR DESCRIPTION
I created this PR to prove that UnmarshalKey doesn't work with time.Duration type. I'm investigating why.