### PR TITLE
Tests for flags handling improved

### DIFF
--- a/viper_test.go
+++ b/viper_test.go
@@ -557,11 +557,9 @@ func TestBindPFlagsStringSlice(t *testing.T) {
 
 			flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
 			flagSet.StringSlice("stringslice", testValue.Expected, "test")
-			flagSet.Visit(func(f *pflag.Flag) {
-				if len(testValue.Value) > 0 {
-					f.Value.Set(testValue.Value)
-					f.Changed = changed
-				}
+			flagSet.VisitAll(func(f *pflag.Flag) {
+				f.Value.Set(testValue.Value)
+				f.Changed = changed
 			})
 
 			err := v.BindPFlags(flagSet)

--- a/viper_test.go
+++ b/viper_test.go
@@ -540,6 +540,8 @@ func TestBindPFlags(t *testing.T) {
 }
 
 func TestBindPFlagsStringSlice(t *testing.T) {
+	defaultVal := []string{"default"}
+
 	for _, testValue := range []struct {
 		Expected []string
 		Value    string
@@ -551,6 +553,8 @@ func TestBindPFlagsStringSlice(t *testing.T) {
 
 		for _, changed := range []bool{true, false} {
 			v := New() // create independent Viper object
+			v.SetDefault("stringslice", defaultVal)
+
 			flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
 			flagSet.StringSlice("stringslice", testValue.Expected, "test")
 			flagSet.Visit(func(f *pflag.Flag) {
@@ -572,7 +576,11 @@ func TestBindPFlagsStringSlice(t *testing.T) {
 			if err := v.Unmarshal(val); err != nil {
 				t.Fatalf("%+#v cannot unmarshal: %s", testValue.Value, err)
 			}
-			assert.Equal(t, testValue.Expected, val.StringSlice)
+			if changed {
+				assert.Equal(t, testValue.Expected, val.StringSlice)
+			} else {
+				assert.Equal(t, defaultVal, val.StringSlice)
+			}
 		}
 	}
 }

--- a/viper_test.go
+++ b/viper_test.go
@@ -540,23 +540,25 @@ func TestBindPFlags(t *testing.T) {
 }
 
 func TestBindPFlagsStringSlice(t *testing.T) {
-	defaultVal := []string{"default"}
-
-	for _, testValue := range []struct {
+	tests := []struct {
 		Expected []string
 		Value    string
 	}{
 		{[]string{}, ""},
 		{[]string{"jeden"}, "jeden"},
 		{[]string{"dwa", "trzy"}, "dwa,trzy"},
-		{[]string{"cztery", "piec , szesc"}, "cztery,\"piec , szesc\""}} {
+		{[]string{"cztery", "piec , szesc"}, "cztery,\"piec , szesc\""},
+	}
+
+	v := New() // create independent Viper object
+	defaultVal := []string{"default"}
+	v.SetDefault("stringslice", defaultVal)
+
+	for _, testValue := range tests {
+		flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		flagSet.StringSlice("stringslice", testValue.Expected, "test")
 
 		for _, changed := range []bool{true, false} {
-			v := New() // create independent Viper object
-			v.SetDefault("stringslice", defaultVal)
-
-			flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
-			flagSet.StringSlice("stringslice", testValue.Expected, "test")
 			flagSet.VisitAll(func(f *pflag.Flag) {
 				f.Value.Set(testValue.Value)
 				f.Changed = changed


### PR DESCRIPTION
Highlighted and fixed a small bug in `TestBindPFlagsStringSlice()` (introduced in recently merged PR #296).

~While I was at it, moved all the flag-related tests from `viper_test.go` to the existing `flags_test.go` for consistency.~

See individual commits for details, they should be clear enough.