### PR TITLE
Handle additional types defined in `spf13/pflag`

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -620,8 +620,14 @@ func (v *Viper) Get(key string) interface{} {
 		return cast.ToTime(val)
 	case time.Duration:
 		return cast.ToDuration(val)
+	case []bool:
+		return cast.ToBoolSlice(val)
 	case []string:
 		return cast.ToStringSlice(val)
+	case []int:
+		return cast.ToIntSlice(val)
+	case []time.Duration:
+		return cast.ToDurationSlice(val)
 	}
 	return val
 }
@@ -893,7 +899,7 @@ func (v *Viper) find(lcaseKey string) interface{} {
 			return cast.ToInt(flag.ValueString())
 		case "bool":
 			return cast.ToBool(flag.ValueString())
-		case "stringSlice":
+		case "stringSlice", "stringArray", "boolSlice", "ipSlice", "uintSlice", "intSlice":
 			s := strings.TrimPrefix(flag.ValueString(), "[")
 			s = strings.TrimSuffix(s, "]")
 			res, _ := readAsCSV(s)
@@ -962,7 +968,7 @@ func (v *Viper) find(lcaseKey string) interface{} {
 			return cast.ToInt(flag.ValueString())
 		case "bool":
 			return cast.ToBool(flag.ValueString())
-		case "stringSlice":
+		case "stringSlice", "stringArray", "boolSlice", "ipSlice", "uintSlice", "intSlice":
 			s := strings.TrimPrefix(flag.ValueString(), "[")
 			s = strings.TrimSuffix(s, "]")
 			res, _ := readAsCSV(s)

--- a/viper.go
+++ b/viper.go
@@ -614,6 +614,8 @@ func (v *Viper) Get(key string) interface{} {
 		return cast.ToString(val)
 	case int64, int32, int16, int8, int:
 		return cast.ToInt(val)
+	case uint64, uint32, uint16, uint8, uint:
+		return cast.ToUint(val)
 	case float64, float32:
 		return cast.ToFloat64(val)
 	case time.Time:
@@ -897,6 +899,8 @@ func (v *Viper) find(lcaseKey string) interface{} {
 		switch flag.ValueType() {
 		case "int", "int8", "int16", "int32", "int64":
 			return cast.ToInt(flag.ValueString())
+		case "uint", "uint8", "uint16", "uint32", "uint64":
+			return cast.ToUint(flag.ValueString())
 		case "bool":
 			return cast.ToBool(flag.ValueString())
 		case "stringSlice", "stringArray", "boolSlice", "ipSlice", "uintSlice", "intSlice":
@@ -966,6 +970,8 @@ func (v *Viper) find(lcaseKey string) interface{} {
 		switch flag.ValueType() {
 		case "int", "int8", "int16", "int32", "int64":
 			return cast.ToInt(flag.ValueString())
+		case "uint", "uint8", "uint16", "uint32", "uint64":
+			return cast.ToUint(flag.ValueString())
 		case "bool":
 			return cast.ToBool(flag.ValueString())
 		case "stringSlice", "stringArray", "boolSlice", "ipSlice", "uintSlice", "intSlice":

--- a/viper.go
+++ b/viper.go
@@ -903,7 +903,7 @@ func (v *Viper) find(lcaseKey string) interface{} {
 			return cast.ToUint(flag.ValueString())
 		case "bool":
 			return cast.ToBool(flag.ValueString())
-		case "stringSlice", "stringArray", "boolSlice", "ipSlice", "uintSlice", "intSlice":
+		case "stringSlice", "stringArray", "boolSlice", "ipSlice", "uintSlice", "intSlice", "durationSlice":
 			s := strings.TrimPrefix(flag.ValueString(), "[")
 			s = strings.TrimSuffix(s, "]")
 			res, _ := readAsCSV(s)
@@ -974,7 +974,7 @@ func (v *Viper) find(lcaseKey string) interface{} {
 			return cast.ToUint(flag.ValueString())
 		case "bool":
 			return cast.ToBool(flag.ValueString())
-		case "stringSlice", "stringArray", "boolSlice", "ipSlice", "uintSlice", "intSlice":
+		case "stringSlice", "stringArray", "boolSlice", "ipSlice", "uintSlice", "intSlice", "durationSlice":
 			s := strings.TrimPrefix(flag.ValueString(), "[")
 			s = strings.TrimSuffix(s, "]")
 			res, _ := readAsCSV(s)


### PR DESCRIPTION
In current implementation many of the types defined in spf13/pflag are not respected, particularly "array" and "slice" types are parsed incorrectly
0967fc9 , which fixes the issue with string slice parsing, but the issue persists with other slice/array types

depends on spf13/pflag#122