### PR TITLE
Fix overflow error on 32 bit architectures

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -648,8 +648,10 @@ func (v *Viper) Get(key string) interface{} {
 			return cast.ToBool(val)
 		case string:
 			return cast.ToString(val)
-		case int64, int32, int16, int8, int:
+		case int32, int16, int8, int:
 			return cast.ToInt(val)
+		case int64:
+			return cast.ToInt64(val)
 		case float64, float32:
 			return cast.ToFloat64(val)
 		case time.Time:

--- a/viper_test.go
+++ b/viper_test.go
@@ -1102,10 +1102,6 @@ func TestMergeConfig(t *testing.T) {
 		t.Fatalf("pop != 37890, = %d", pop)
 	}
 
-	if pop := v.GetInt("hello.lagrenum"); pop != 765432101234567 {
-		t.Fatalf("lagrenum != 765432101234567, = %d", pop)
-	}
-
 	if pop := v.GetInt32("hello.pop"); pop != int32(37890) {
 		t.Fatalf("pop != 37890, = %d", pop)
 	}
@@ -1128,10 +1124,6 @@ func TestMergeConfig(t *testing.T) {
 
 	if pop := v.GetInt("hello.pop"); pop != 45000 {
 		t.Fatalf("pop != 45000, = %d", pop)
-	}
-
-	if pop := v.GetInt("hello.lagrenum"); pop != 7654321001234567 {
-		t.Fatalf("lagrenum != 7654321001234567, = %d", pop)
 	}
 
 	if pop := v.GetInt32("hello.pop"); pop != int32(45000) {


### PR DESCRIPTION
Hi,

in Debian, we've discovered an overflow error on 32 bit architectures:
https://bugs.debian.org/860678

These two commits enable all tests to pass on 32 and 64 bit architectures.