### PR TITLE
Feature/unmarshal with meta

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -53,7 +53,7 @@ func init() {
 type remoteConfigFactory interface {
 	Get(rp RemoteProvider) (io.Reader, error)
 	Watch(rp RemoteProvider) (io.Reader, error)
-	WatchChannel(rp RemoteProvider)(<-chan *RemoteResponse, chan bool)
+	WatchChannel(rp RemoteProvider) (<-chan *RemoteResponse, chan bool)
 }
 
 // RemoteConfig is optional, see the remote package
@@ -746,7 +746,7 @@ func (v *Viper) Unmarshal(rawVal interface{}) error {
 	return nil
 }
 
-// defaultDecoderConfig returns default mapsstructure.DecoderConfig with suppot
+// defaultDecoderConfig returns default mapsstructure.DecoderConfig with support
 // of time.Duration values
 func defaultDecoderConfig(output interface{}) *mapstructure.DecoderConfig {
 	return &mapstructure.DecoderConfig{

--- a/viper.go
+++ b/viper.go
@@ -731,6 +731,27 @@ func (v *Viper) UnmarshalKey(key string, rawVal interface{}) error {
 	return nil
 }
 
+// UnmarshalKeyWithMeta performs UnmarshalKey and using an additional
+// parameter, also provides access to the mapstructure.Metadata.
+func UnmarshalKeyWithMeta(key string, rawVal interface{}) (mapstructure.Metadata, error) {
+	return v.UnmarshalKeyWithMeta(key, rawVal)
+}
+func (v *Viper) UnmarshalKeyWithMeta(key string, rawVal interface{}) (mapstructure.Metadata, error) {
+	var meta mapstructure.Metadata
+	config := defaultDecoderConfig(rawVal)
+	config.Metadata = &meta
+
+	err := decode(v.Get(key), config)
+
+	if err != nil {
+		return meta, err
+	}
+
+	v.insensitiviseMaps()
+
+	return meta, nil
+}
+
 // Unmarshal unmarshals the config into a Struct. Make sure that the tags
 // on the fields of the structure are properly set.
 func Unmarshal(rawVal interface{}) error { return v.Unmarshal(rawVal) }
@@ -744,6 +765,27 @@ func (v *Viper) Unmarshal(rawVal interface{}) error {
 	v.insensitiviseMaps()
 
 	return nil
+}
+
+// UnmarshalWithMeta performs Unmarshal and using an additional
+// parameter, also provides access to the mapstructure.Metadata.
+func UnmarshalWithMeta(rawVal interface{}) (mapstructure.Metadata, error) {
+	return v.UnmarshalWithMeta(rawVal)
+}
+func (v *Viper) UnmarshalWithMeta(rawVal interface{}) (mapstructure.Metadata, error) {
+	var meta mapstructure.Metadata
+	config := defaultDecoderConfig(rawVal)
+	config.Metadata = &meta
+
+	err := decode(v.AllSettings(), config)
+
+	if err != nil {
+		return meta, err
+	}
+
+	v.insensitiviseMaps()
+
+	return meta, nil
 }
 
 // defaultDecoderConfig returns default mapsstructure.DecoderConfig with support

--- a/viper_test.go
+++ b/viper_test.go
@@ -275,6 +275,85 @@ func TestUnmarshalling(t *testing.T) {
 	assert.Equal(t, 35, Get("age"))
 }
 
+func ExampleUnmarshalWithMeta() {
+	v := New()
+	type Lib struct {
+		Name    string
+		Awesome bool
+		Useful  bool
+	}
+	var libsCfg struct {
+		Libs map[string]Lib
+	}
+	v.config = map[string]interface{}{
+		"libs": map[string]interface{}{
+			"viper": map[string]interface{}{
+				"name":    "Viper",
+				"awesome": true,
+				"tagline": "Go configuration with fangs!",
+			},
+		},
+		"numbers": []int{4, 8, 15, 16, 23, 42},
+	}
+	meta, _ := v.UnmarshalWithMeta(&libsCfg)
+	// The keys slice is not stable. Sorting them in lexicographical
+	// order allows comparison.
+	sort.Strings(meta.Keys)
+	sort.Strings(meta.Unused)
+	fmt.Printf("%#v\n", meta.Keys)
+	fmt.Printf("%#v", meta.Unused)
+	// Output:
+	// []string{"Libs", "Libs[viper]", "Libs[viper]", "Libs[viper].Awesome", "Libs[viper].Name"}
+	// []string{"Libs[viper].tagline", "numbers"}
+}
+
+func ExampleUnmarshalKeyWithMeta() {
+	v := New()
+	var lib struct {
+		Name    string
+		Awesome bool
+		Useful  bool
+	}
+	v.config = map[string]interface{}{
+		"libs": map[string]interface{}{
+			"viper": map[string]interface{}{
+				"name":    "Viper",
+				"awesome": true,
+				"tagline": "Go configuration with fangs!",
+			},
+		},
+	}
+	meta, _ := v.UnmarshalKeyWithMeta("libs.viper", &lib)
+	fmt.Println(meta.Keys)
+	fmt.Println(meta.Unused)
+	// Output:
+	// [Name Awesome]
+	// [tagline]
+}
+
+func TestUnmarshalKeyWithMeta(t *testing.T) {
+	v := New()
+	v.SetConfigType("yaml")
+	err := v.ReadConfig(bytes.NewBuffer(yamlExample))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var clothes struct {
+		Jacket string
+		Pants  interface{}
+	}
+	meta, err := v.UnmarshalKeyWithMeta("clothing", &clothes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys := []string{"Jacket", "Pants"}
+	unused := []string{"trousers"}
+	sort.Strings(meta.Keys)
+	sort.Strings(meta.Unused)
+	assert.Equal(t, keys, meta.Keys, "keys decoded")
+	assert.Equal(t, unused, meta.Unused, "keys in config not in struct")
+}
+
 func TestUnmarshalExact(t *testing.T) {
 	vip := New()
 	target := &testUnmarshalExtra{}


### PR DESCRIPTION
Added parallel functions/methods to unmarshal data and return `mapstructure.Metadata`. This was not added for `UnmarshalExact`, since all keys should be used and none left unused.

Add a tests and examples for each new method.

Fixes #341