### PR TITLE
Add glide file for dependency management

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,19 @@
+package: github.com/spf13/viper
+import:
+- package: github.com/fsnotify/fsnotify
+- package: github.com/hashicorp/hcl
+- package: github.com/magiconair/properties
+- package: github.com/mitchellh/mapstructure
+- package: github.com/pelletier/go-toml
+- package: github.com/spf13/afero
+- package: github.com/spf13/cast
+- package: github.com/spf13/jwalterweatherman
+- package: github.com/spf13/pflag
+- package: github.com/xordataexchange/crypt
+  subpackages:
+  - config
+- package: gopkg.in/yaml.v2
+testImport:
+- package: github.com/stretchr/testify
+  subpackages:
+  - assert


### PR DESCRIPTION
There are currently no vendor packages for this repository and I would like to propose that a glide file be added for simplifying dependency management.  Glide is an extremely useful tool and will only require users to `glide update` to pull in all required dependencies.

https://glide.sh/
