### PR TITLE
Viper `Unmarshal` example fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ type config struct {
 
 var C config
 
-err := Unmarshal(&C)
+err := viper.Unmarshal(&C)
 if err != nil {
 	t.Fatalf("unable to decode into struct, %v", err)
 }


### PR DESCRIPTION
The example for "Unmarshaling" in the README calls `Unmarshal` without a receiver. It might be clearer to indicate the receiver, either `viper` or a `viper_runtime`