### PR TITLE
Add UnmarshalKeyExact

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -768,11 +768,29 @@ func decode(input interface{}, config *mapstructure.DecoderConfig) error {
 
 // UnmarshalExact unmarshals the config into a Struct, erroring if a field is nonexistent
 // in the destination struct.
+func UnmarshalExact(rawVal interface{}) error { return v.UnmarshalExact(rawVal) }
 func (v *Viper) UnmarshalExact(rawVal interface{}) error {
 	config := defaultDecoderConfig(rawVal)
 	config.ErrorUnused = true
 
 	err := decode(v.AllSettings(), config)
+
+	if err != nil {
+		return err
+	}
+
+	v.insensitiviseMaps()
+
+	return nil
+}
+// UnmarshalKeyExact takes a single key and unmarshals it into a Struct, erroring if a field
+// is nonexistent in the destination struct.
+func UnmarshalKeyExact(key string, rawVal interface{}) error { return v.UnmarshalKeyExact(key, rawVal) }
+func (v *Viper) UnmarshalKeyExact(key string, rawVal interface{}) error {
+	config := defaultDecoderConfig(rawVal)
+	config.ErrorUnused = true
+
+	err := decode(v.Get(key), config)
 
 	if err != nil {
 		return err

--- a/viper_test.go
+++ b/viper_test.go
@@ -287,6 +287,37 @@ func TestUnmarshalExact(t *testing.T) {
 	}
 }
 
+func TestUnmarshalKeyExact(t *testing.T) {
+	type duration struct {
+		Delay time.Duration
+	}
+
+	type item struct {
+		Name   string
+		Delay  time.Duration
+		Nested duration
+	}
+
+	config := `invalid_but_irrelevant=true
+        [[parent]]
+        error=true
+	delay="100ms"
+	[parent.nested]
+	delay="200ms"
+`
+	initConfig("toml", config)
+
+	var items []item
+	err := v.UnmarshalKeyExact("parent", &items)
+	if err == nil {
+		t.Fatal("UnmarshalKeyExact should error when populating a struct from a conf that contains unused fields")
+	}
+
+	assert.Equal(t, 1, len(items))
+	assert.Equal(t, 100*time.Millisecond, items[0].Delay)
+	assert.Equal(t, 200*time.Millisecond, items[0].Nested.Delay)
+}
+
 func TestOverrides(t *testing.T) {
 	Set("age", 40)
 	assert.Equal(t, 40, Get("age"))


### PR DESCRIPTION
I wanted to unmarshal a subset of the config but get the benefit of option validation, so I implemented UnmarshalKeyExact and added a test for it. I also added a non-method version of UnmarshalExact(), which was missing for some reason I didn't understand.