### PR TITLE
Fix retrieval of pflag stringArray

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -896,7 +896,7 @@ func (v *Viper) find(lcaseKey string) interface{} {
 			return cast.ToInt(flag.ValueString())
 		case "bool":
 			return cast.ToBool(flag.ValueString())
-		case "stringSlice":
+		case "stringSlice", "stringArray":
 			s := strings.TrimPrefix(flag.ValueString(), "[")
 			s = strings.TrimSuffix(s, "]")
 			res, _ := readAsCSV(s)
@@ -965,7 +965,7 @@ func (v *Viper) find(lcaseKey string) interface{} {
 			return cast.ToInt(flag.ValueString())
 		case "bool":
 			return cast.ToBool(flag.ValueString())
-		case "stringSlice":
+		case "stringSlice", "stringArray":
 			s := strings.TrimPrefix(flag.ValueString(), "[")
 			s = strings.TrimSuffix(s, "]")
 			res, _ := readAsCSV(s)


### PR DESCRIPTION
`pflag.StringArray` suffers from the same problems as `StringSlice` did described in this issue https://github.com/spf13/viper/issues/112