### PR TITLE
Fix incorrect name of function in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ with ENV:
  * `AutomaticEnv()`
  * `BindEnv(string...) : error`
  * `SetEnvPrefix(string)`
- * `SetEnvReplacer(string...) *strings.Replacer`
+ * `SetEnvKeyReplacer(string...) *strings.Replacer`
 
 _When working with ENV variables, it’s important to recognize that Viper
 treats ENV variables as case sensitive._
@@ -212,7 +212,7 @@ time a `viper.Get` request is made. It will apply the following rules. It will
 check for a environment variable with a name matching the key uppercased and
 prefixed with the `EnvPrefix` if set.
 
-`SetEnvReplacer` allows you to use a `strings.Replacer` object to rewrite Env
+`SetEnvKeyReplacer` allows you to use a `strings.Replacer` object to rewrite Env
 keys to an extent. This is useful if you want to use `-` or something in your
 `Get()` calls, but want your environmental variables to use `_` delimiters. An
 example of using it can be found in `viper_test.go`.

--- a/viper_test.go
+++ b/viper_test.go
@@ -417,7 +417,7 @@ func TestAutoEnvWithPrefix(t *testing.T) {
 	assert.Equal(t, "13", Get("bar"))
 }
 
-func TestSetEnvReplacer(t *testing.T) {
+func TestSetEnvKeyReplacer(t *testing.T) {
 	Reset()
 
 	AutomaticEnv()


### PR DESCRIPTION
Change `SetEnvReplacer` to `SetEnvKeyReplacer`