### PR TITLE
Allow exists util function to take afero.Fs

### DIFF
--- a/util.go
+++ b/util.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/hcl"
 	"github.com/magiconair/properties"
 	toml "github.com/pelletier/go-toml"
+	"github.com/spf13/afero"
 	"github.com/spf13/cast"
 	jww "github.com/spf13/jwalterweatherman"
 	"gopkg.in/yaml.v2"
@@ -121,8 +122,8 @@ func absPathify(inPath string) string {
 }
 
 // Check if File / Directory Exists
-func exists(path string) (bool, error) {
-	_, err := v.fs.Stat(path)
+func exists(fs afero.Fs, path string) (bool, error) {
+	_, err := fs.Stat(path)
 	if err == nil {
 		return true, nil
 	}

--- a/viper.go
+++ b/viper.go
@@ -1537,7 +1537,7 @@ func (v *Viper) searchInPath(in string) (filename string) {
 	jww.DEBUG.Println("Searching for config in ", in)
 	for _, ext := range SupportedExts {
 		jww.DEBUG.Println("Checking for", filepath.Join(in, v.configName+"."+ext))
-		if b, _ := exists(filepath.Join(in, v.configName+"."+ext)); b {
+		if b, _ := exists(v.fs, filepath.Join(in, v.configName+"."+ext)); b {
 			jww.DEBUG.Println("Found: ", filepath.Join(in, v.configName+"."+ext))
 			return filepath.Join(in, v.configName+"."+ext)
 		}


### PR DESCRIPTION
This allows it to work with non-default instances of Viper as you would expect. `searchInPath` then passes it's own instance of `fs`.

Signed-off-by: Jeff Lindsay <progrium@gmail.com>