### PR TITLE
WatchConfig and Kubernetes (#284)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ _testmain.go
 *.exe
 *.test
 *.bench
+
+.vscode
+
+# exclude dependencies in the `/vendor` folder
+vendor

--- a/viper.go
+++ b/viper.go
@@ -319,7 +319,7 @@ func (v *Viper) WatchConfig() {
 						realConfigFile = currentConfigFile
 						err := v.ReadInConfig()
 						if err != nil {
-							log.Printf("error reading file: %v\n", err)
+							log.Printf("error reading config file: %v\n", err)
 						}
 						if v.onConfigChange != nil {
 							v.onConfigChange(event)
@@ -343,7 +343,6 @@ func (v *Viper) WatchConfig() {
 		initWG.Done()   // done initalizing the watch in this go routine, so the parent routine can move on...
 		eventsWG.Wait() // now, wait for event loop to end in this go-routine...
 	}()
-	fmt.Println(" init WG done")
 	initWG.Wait() // make sure that the go routine above fully ended before returning
 }
 

--- a/viper_test.go
+++ b/viper_test.go
@@ -1419,9 +1419,11 @@ func newViperWithSymlinkedConfigFile(t *testing.T) (*Viper, string, string, func
 }
 
 func TestWatchFile(t *testing.T) {
+
 	t.Run("file content changed", func(t *testing.T) {
 		// given a `config.yaml` file being watched
 		v, configFile, cleanup := newViperWithConfigFile(t)
+		fmt.Printf("test config file: %s\n", configFile)
 		defer cleanup()
 		wg := sync.WaitGroup{}
 		v.WatchConfig()
@@ -1466,7 +1468,6 @@ func TestWatchFile(t *testing.T) {
 		// then
 		require.Nil(t, err)
 		assert.Equal(t, "baz", v.Get("foo"))
-
 	})
 
 }

--- a/viper_test.go
+++ b/viper_test.go
@@ -1469,17 +1469,19 @@ func TestWatchFile(t *testing.T) {
 	t.Run("file content changed", func(t *testing.T) {
 		// given a `config.yaml` file being watched
 		v, configFile, cleanup := newViperWithConfigFile(t)
-		fmt.Printf("test config file: %s\n", configFile)
 		defer cleanup()
+		_, err := os.Stat(configFile)
+		require.NoError(t, err)
+		t.Logf("test config file: %s\n", configFile)
 		wg := sync.WaitGroup{}
 		wg.Add(1)
-		v.WatchConfig()
 		v.OnConfigChange(func(in fsnotify.Event) {
 			t.Logf("config file changed")
 			wg.Done()
 		})
+		v.WatchConfig()
 		// when overwriting the file and waiting for the custom change notification handler to be triggered
-		err := ioutil.WriteFile(configFile, []byte("foo: baz\n"), 0640)
+		err = ioutil.WriteFile(configFile, []byte("foo: baz\n"), 0640)
 		wg.Wait()
 		// then the config value should have changed
 		require.Nil(t, err)

--- a/viper_test.go
+++ b/viper_test.go
@@ -11,18 +11,23 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/afero"
 	"github.com/spf13/cast"
 
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var yamlExample = []byte(`Hacker: true
@@ -1365,6 +1370,104 @@ func doTestCaseInsensitive(t *testing.T, typ, config string) {
 	assert.Equal(t, 3, cast.ToInt(Get("ef.ijk")))
 	assert.Equal(t, 4, cast.ToInt(Get("ef.lm.no")))
 	assert.Equal(t, 5, cast.ToInt(Get("ef.lm.p.q")))
+
+}
+
+func newViperWithConfigFile(t *testing.T) (*Viper, string, func()) {
+	watchDir, err := ioutil.TempDir("", "")
+	require.Nil(t, err)
+	configFile := path.Join(watchDir, "config.yaml")
+	err = ioutil.WriteFile(configFile, []byte("foo: bar\n"), 0640)
+	require.Nil(t, err)
+	cleanup := func() {
+		os.RemoveAll(watchDir)
+	}
+	v := New()
+	v.SetConfigFile(configFile)
+	err = v.ReadInConfig()
+	require.Nil(t, err)
+	require.Equal(t, "bar", v.Get("foo"))
+	return v, configFile, cleanup
+}
+
+func newViperWithSymlinkedConfigFile(t *testing.T) (*Viper, string, string, func()) {
+	watchDir, err := ioutil.TempDir("", "")
+	require.Nil(t, err)
+	dataDir1 := path.Join(watchDir, "data1")
+	err = os.Mkdir(dataDir1, 0777)
+	require.Nil(t, err)
+	realConfigFile := path.Join(dataDir1, "config.yaml")
+	t.Logf("Real config file location: %s\n", realConfigFile)
+	err = ioutil.WriteFile(realConfigFile, []byte("foo: bar\n"), 0640)
+	require.Nil(t, err)
+	cleanup := func() {
+		os.RemoveAll(watchDir)
+	}
+	// now, symlink the tm `data1` dir to `data` in the baseDir
+	os.Symlink(dataDir1, path.Join(watchDir, "data"))
+	// and link the `<watchdir>/datadir1/config.yaml` to `<watchdir>/config.yaml`
+	configFile := path.Join(watchDir, "config.yaml")
+	os.Symlink(path.Join(watchDir, "data", "config.yaml"), configFile)
+	fmt.Printf("Config file location: %s\n", path.Join(watchDir, "config.yaml"))
+	// init Viper
+	v := New()
+	v.SetConfigFile(configFile)
+	err = v.ReadInConfig()
+	require.Nil(t, err)
+	require.Equal(t, "bar", v.Get("foo"))
+	return v, watchDir, configFile, cleanup
+}
+
+func TestWatchFile(t *testing.T) {
+	t.Run("file content changed", func(t *testing.T) {
+		// given a `config.yaml` file being watched
+		v, configFile, cleanup := newViperWithConfigFile(t)
+		defer cleanup()
+		wg := sync.WaitGroup{}
+		v.WatchConfig()
+		v.OnConfigChange(func(in fsnotify.Event) {
+			t.Logf("config file changed")
+			wg.Done()
+		})
+		wg.Add(1)
+		// when overwriting the file and waiting for the custom change notification handler to be triggered
+		err := ioutil.WriteFile(configFile, []byte("foo: baz\n"), 0640)
+		wg.Wait()
+		// then the config value should have changed
+		require.Nil(t, err)
+		assert.Equal(t, "baz", v.Get("foo"))
+	})
+
+	t.Run("link to real file changed (à la Kubernetes)", func(t *testing.T) {
+		// skip if not executed on Linux
+		if runtime.GOOS != "linux" {
+			t.Skipf("Skipping test as symlink replacements don't work on non-linux environment...")
+		}
+		v, watchDir, _, _ := newViperWithSymlinkedConfigFile(t)
+		// defer cleanup()
+		wg := sync.WaitGroup{}
+		v.WatchConfig()
+		v.OnConfigChange(func(in fsnotify.Event) {
+			t.Logf("config file changed")
+			wg.Done()
+		})
+		wg.Add(1)
+		// when link to another `config.yaml` file
+		dataDir2 := path.Join(watchDir, "data2")
+		err := os.Mkdir(dataDir2, 0777)
+		require.Nil(t, err)
+		configFile2 := path.Join(dataDir2, "config.yaml")
+		err = ioutil.WriteFile(configFile2, []byte("foo: baz\n"), 0640)
+		require.Nil(t, err)
+		// change the symlink using the `ln -sfn` command
+		err = exec.Command("ln", "-sfn", dataDir2, path.Join(watchDir, "data")).Run()
+		require.Nil(t, err)
+		wg.Wait()
+		// then
+		require.Nil(t, err)
+		assert.Equal(t, "baz", v.Get("foo"))
+
+	})
 
 }
 

--- a/viper_test.go
+++ b/viper_test.go
@@ -1426,12 +1426,12 @@ func TestWatchFile(t *testing.T) {
 		fmt.Printf("test config file: %s\n", configFile)
 		defer cleanup()
 		wg := sync.WaitGroup{}
+		wg.Add(1)
 		v.WatchConfig()
 		v.OnConfigChange(func(in fsnotify.Event) {
 			t.Logf("config file changed")
 			wg.Done()
 		})
-		wg.Add(1)
 		// when overwriting the file and waiting for the custom change notification handler to be triggered
 		err := ioutil.WriteFile(configFile, []byte("foo: baz\n"), 0640)
 		wg.Wait()


### PR DESCRIPTION
Support override of symlink to config file
Include tests for WatchConfig of regular files, as well
as config file which links to a folder which is itself a
link to another folder in the same "watch dir" (the way
Kubernetes exposes config files from ConfigMaps mounted
on a volume in a Pod)

Also:
- Add synchronization with WaitGroup to ensure that the WatchConfig
is properly started before returning
- Remove the watcher when the Config file is removed.

Fixes #284

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>