### PR TITLE
Document reading a specific config file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ if err != nil { // Handle errors reading the config file
 }
 ```
 
+Alternatively (or in addition), the path to a specific config file,
+rather than to a directory containing config files, can be provided.
+
+```go
+viper.SetConfigFile("$HOME/customconfig.toml") // explicitly add a specific config file
+err := viper.ReadInConfig() // read the config file
+if err != nil { // Handle errors reading the config file
+	panic(fmt.Errorf("Fatal error config file: %s \n", err))
+}
+```
+
 ### Watching and re-reading config files
 
 Viper supports the ability to have your application live read a config file while running.


### PR DESCRIPTION
I think that specifying a particular config file using `SetConfigFile()` is a rather common use case, therefore it deserves mention in the README, which is the first (and perhaps only) documentation a user who's new to the library reads.