### PR TITLE
Added functionality to mock the environment variable store, for tests

### DIFF
--- a/util.go
+++ b/util.go
@@ -94,16 +94,16 @@ func insensitiviseMap(m map[string]interface{}) {
 	}
 }
 
-func absPathify(inPath string) string {
+func absPathify(inPath string, envStore EnvStore) string {
 	jww.INFO.Println("Trying to resolve absolute path to", inPath)
 
 	if strings.HasPrefix(inPath, "$HOME") {
-		inPath = userHomeDir() + inPath[5:]
+		inPath = userHomeDir(envStore) + inPath[5:]
 	}
 
 	if strings.HasPrefix(inPath, "$") {
 		end := strings.Index(inPath, string(os.PathSeparator))
-		inPath = os.Getenv(inPath[1:end]) + inPath[end:]
+		inPath = envStore.Get(inPath[1:end]) + inPath[end:]
 	}
 
 	if filepath.IsAbs(inPath) {
@@ -141,15 +141,15 @@ func stringInSlice(a string, list []string) bool {
 	return false
 }
 
-func userHomeDir() string {
+func userHomeDir(store EnvStore) string {
 	if runtime.GOOS == "windows" {
-		home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+		home := store.Get("HOMEDRIVE") + store.Get("HOMEPATH")
 		if home == "" {
-			home = os.Getenv("USERPROFILE")
+			home = store.Get("USERPROFILE")
 		}
 		return home
 	}
-	return os.Getenv("HOME")
+	return store.Get("HOME")
 }
 
 func unmarshallConfigReader(in io.Reader, c map[string]interface{}, configType string) error {

--- a/viper.go
+++ b/viper.go
@@ -100,7 +100,7 @@ type EnvStore interface {
 	Get(key string) string
 }
 
-type RealEnvStore struct {}
+type RealEnvStore struct{}
 
 func (e *RealEnvStore) Get(key string) string {
 	return os.Getenv(key)
@@ -174,7 +174,7 @@ type Viper struct {
 
 	onConfigChange func(fsnotify.Event)
 
-	envStore       EnvStore
+	envStore EnvStore
 }
 
 func baseNew() *Viper {

--- a/viper_test.go
+++ b/viper_test.go
@@ -360,6 +360,50 @@ func TestRemotePrecedence(t *testing.T) {
 	Set("newkey", "remote")
 }
 
+type mapEnv struct {
+	m map[string]string
+}
+
+func (e *mapEnv) Get(key string) string {
+	if val, ok := e.m[key]; ok {
+		return val
+	} else {
+		return ""
+	}
+}
+
+func (e *mapEnv) Set(key, value string) {
+	e.m[key] = value
+}
+
+func newMapEnv() *mapEnv {
+	mapEnv := new(mapEnv)
+	mapEnv.m = make(map[string]string)
+	return mapEnv
+}
+
+func TestMockEnv(t *testing.T) {
+	e := newMapEnv()
+
+	initJSON()
+	v.SetEnvStore(e)
+
+	BindEnv("id")
+	BindEnv("f", "FOOD")
+
+	e.Set("ID", "13")
+	e.Set("FOOD", "apple")
+	e.Set("NAME", "crunk")
+
+	assert.Equal(t, "13", Get("id"))
+	assert.Equal(t, "apple", Get("f"))
+	assert.Equal(t, "Cake", Get("name"))
+
+	AutomaticEnv()
+
+	assert.Equal(t, "crunk", Get("name"))
+}
+
 func TestEnv(t *testing.T) {
 	initJSON()
 


### PR DESCRIPTION
Mocking the filesystem is already possible using afero and the SetFs function.
This PR adds the option to mock the environment variable store as well, with the default implementation of OS environment variables.
I find it helpful when testing code that uses viper; the previous option of mutating the shared OS environment state interferes with running tests in parallel.
