### PR TITLE
fix: WatchConfig leads to panic if OnConfigChange is not called

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -289,7 +289,10 @@ func (v *Viper) WatchConfig() {
 							if err != nil {
 								log.Println("error:", err)
 							}
-							v.onConfigChange(event)
+
+							if v.onConfigChange != nil {
+								v.onConfigChange(event)
+							}
 						}
 					}
 				case err := <-watcher.Errors:


### PR DESCRIPTION
`OnConfigChange` should be optional.