### PR TITLE
Use 'viper' as decoder tag name

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ Example:
 type config struct {
 	Port int
 	Name string
-	PathMap string `mapstructure:"path_map"`
+	PathMap string `viper:"path_map"`
 }
 
 var C config

--- a/viper.go
+++ b/viper.go
@@ -774,6 +774,7 @@ func defaultDecoderConfig(output interface{}) *mapstructure.DecoderConfig {
 		Metadata:         nil,
 		Result:           output,
 		WeaklyTypedInput: true,
+		TagName:          "viper",
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
 			mapstructure.StringToTimeDurationHookFunc(),
 			mapstructure.StringToSliceHookFunc(","),


### PR DESCRIPTION
This PR changes the decoder tag name from "mapstructure" to "viper".

**NOTE** - this PR depends on https://github.com/mitchellh/mapstructure/pull/107 to prevent breaking changes. If merged before the `mapstructure` PR, any previous implementations of `viper` that use `mapstructure` as the tag name will break.