### PR TITLE
Fix SafeWriteConfig

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1246,15 +1246,9 @@ func (v *Viper) writeConfig(filename string, force bool) error {
 	if v.config == nil {
 		v.config = make(map[string]interface{})
 	}
-	var flags int
-	if force == true {
-		flags = os.O_CREATE | os.O_TRUNC | os.O_WRONLY
-	} else {
-		if _, err := os.Stat(filename); os.IsNotExist(err) {
-			flags = os.O_WRONLY
-		} else {
-			return fmt.Errorf("File: %s exists. Use WriteConfig to overwrite.", filename)
-		}
+	flags := os.O_CREATE | os.O_TRUNC | os.O_WRONLY
+	if !force {
+		flags |= os.O_EXCL
 	}
 	f, err := v.fs.OpenFile(filename, flags, os.FileMode(0644))
 	if err != nil {


### PR DESCRIPTION
If the config file does not exist and the force flag is not set,
OpenFile would not use O_CREATE flag, causing viper to fail with
error "File not exist" and to not create the config file.
This patch changes the behavior of writeConfig() so that if force is set
to false, OpenFile will use O_EXCL flag, thus failing if the file
already exists or creating a new file otherwise.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>