### PR TITLE
Fix incorrect import casing

### DIFF
--- a/util.go
+++ b/util.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cast"
-	jww "github.com/spf13/jwalterweatherman"
+	jww "github.com/spf13/jWalterWeatherman"
 )
 
 // ConfigParseError denotes failing to parse configuration file.

--- a/viper.go
+++ b/viper.go
@@ -42,7 +42,7 @@ import (
 	toml "github.com/pelletier/go-toml"
 	"github.com/spf13/afero"
 	"github.com/spf13/cast"
-	jww "github.com/spf13/jwalterweatherman"
+	jww "github.com/spf13/jWalterWeatherman"
 	"github.com/spf13/pflag"
 )
 


### PR DESCRIPTION
[vgo](https://research.swtch.com/vgo-intro) is currently picky about import casing when downloading deps using the GitHub API:

```
        import "github.com/spf13/viper" ->
        import "github.com/spf13/jwalterweatherman": module path of repo is github.com/spf13/jWalterWeatherman, not github.com/spf13/jwalterweatherman (wrong case)
```

Fixes #466