### PR TITLE
Added Viper.EnvSettings method

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1675,6 +1675,26 @@ func (v *Viper) AllSettings() map[string]interface{} {
 	return m
 }
 
+// EnvSettings returns a map[string]interface{} containing all settings set
+// through environment variables.
+func EnvSettings() map[string]interface{} { return v.EnvSettings() }
+func (v *Viper) EnvSettings() map[string]interface{} {
+	m := map[string]interface{}{}
+	// start from the list of keys, and construct the map one value at a time
+	for _, k := range v.AllKeys() {
+		value := v.getEnv(v.mergeWithEnvPrefix(k))
+		if value == "" {
+			continue
+		}
+		path := strings.Split(k, v.keyDelim)
+		lastKey := strings.ToLower(path[len(path)-1])
+		deepestMap := deepSearch(m, path[0:len(path)-1])
+		// set innermost value
+		deepestMap[lastKey] = true
+	}
+	return m
+}
+
 // SetFs sets the filesystem to use to read configuration.
 func SetFs(fs afero.Fs) { v.SetFs(fs) }
 func (v *Viper) SetFs(fs afero.Fs) {


### PR DESCRIPTION
This is a followup to https://github.com/spf13/viper/issues/469 that adds a `Viper.EnvSettings` method which returns a map of all settings set through environment variables similar to `Viper.AllSettings`. I'm hoping it might be useful for someone else.

Let me know if there's anything that I'm missing or anything that should be done differently.