### PR TITLE
Allow Sub Viper to work with PFlags & nil check on binding PFlags

### DIFF
--- a/flags_test.go
+++ b/flags_test.go
@@ -45,7 +45,7 @@ func TestBindFlagValueSet(t *testing.T) {
 
 func TestBindFlagValue(t *testing.T) {
 	var testString = "testing"
-	var testValue = newStringValue(testString, &testString)
+	var testValue = newStringValue(testString)
 
 	flag := &pflag.Flag{
 		Name:    "testflag",

--- a/viper.go
+++ b/viper.go
@@ -811,6 +811,9 @@ func (v *Viper) UnmarshalExact(rawVal interface{}) error {
 // name as the config key.
 func BindPFlags(flags *pflag.FlagSet) error { return v.BindPFlags(flags) }
 func (v *Viper) BindPFlags(flags *pflag.FlagSet) error {
+	if flags == nil {
+		return fmt.Errorf("FlagSet cannot be nil")
+	}
 	return v.BindFlagValues(pflagValueSet{flags})
 }
 
@@ -822,6 +825,9 @@ func (v *Viper) BindPFlags(flags *pflag.FlagSet) error {
 //
 func BindPFlag(key string, flag *pflag.Flag) error { return v.BindPFlag(key, flag) }
 func (v *Viper) BindPFlag(key string, flag *pflag.Flag) error {
+	if flag == nil {
+		return fmt.Errorf("flag for %q is nil", key)
+	}
 	return v.BindFlagValue(key, pflagValue{flag})
 }
 

--- a/viper_test.go
+++ b/viper_test.go
@@ -224,9 +224,8 @@ func initDirs(t *testing.T) (string, string, func()) {
 //stubs for PFlag Values
 type stringValue string
 
-func newStringValue(val string, p *string) *stringValue {
-	*p = val
-	return (*stringValue)(p)
+func newStringValue(val string) *stringValue {
+	return (*stringValue)(&val)
 }
 
 func (s *stringValue) Set(val string) error {
@@ -587,7 +586,7 @@ func TestBindPFlagsNil(t *testing.T) {
 
 func TestBindPFlag(t *testing.T) {
 	var testString = "testing"
-	var testValue = newStringValue(testString, &testString)
+	var testValue = newStringValue(testString)
 
 	flag := &pflag.Flag{
 		Name:    "testflag",
@@ -623,7 +622,7 @@ func TestBoundCaseSensitivity(t *testing.T) {
 	assert.Equal(t, "blue", Get("eyes"))
 
 	var testString = "green"
-	var testValue = newStringValue(testString, &testString)
+	var testValue = newStringValue(testString)
 
 	flag := &pflag.Flag{
 		Name:    "eyeballs",
@@ -850,6 +849,31 @@ func TestSub(t *testing.T) {
 	v := New()
 	v.SetConfigType("yaml")
 	v.ReadConfig(bytes.NewBuffer(yamlExample))
+
+	subv := v.Sub("clothing")
+	assert.Equal(t, v.Get("clothing.pants.size"), subv.Get("pants.size"))
+
+	subv = v.Sub("clothing.pants")
+	assert.Equal(t, v.Get("clothing.pants.size"), subv.Get("size"))
+
+	subv = v.Sub("clothing.pants.size")
+	assert.Equal(t, (*Viper)(nil), subv)
+
+	subv = v.Sub("missing.key")
+	assert.Equal(t, (*Viper)(nil), subv)
+}
+
+func TestSubPflags(t *testing.T) {
+	v := New()
+
+	// same as yamlExample, without hobbies
+	v.BindPFlag("name", &pflag.Flag{Value: newStringValue("steve"), Changed: true})
+	v.BindPFlag("clothing.jacket", &pflag.Flag{Value: newStringValue("leather"), Changed: true})
+	v.BindPFlag("clothing.trousers", &pflag.Flag{Value: newStringValue("denim"), Changed: true})
+	v.BindPFlag("clothing.pants.size", &pflag.Flag{Value: newStringValue("large"), Changed: true})
+	v.BindPFlag("age", &pflag.Flag{Value: newStringValue("35"), Changed: true})
+	v.BindPFlag("eyes", &pflag.Flag{Value: newStringValue("brown"), Changed: true})
+	v.BindPFlag("beard", &pflag.Flag{Value: newStringValue("yes"), Changed: true})
 
 	subv := v.Sub("clothing")
 	assert.Equal(t, v.Get("clothing.pants.size"), subv.Get("pants.size"))

--- a/viper_test.go
+++ b/viper_test.go
@@ -577,6 +577,14 @@ func TestBindPFlagsStringSlice(t *testing.T) {
 	}
 }
 
+func TestBindPFlagsNil(t *testing.T) {
+	v := New()
+	err := v.BindPFlags(nil)
+	if err == nil {
+		t.Fatalf("expected error when passing nil to BindPFlags")
+	}
+}
+
 func TestBindPFlag(t *testing.T) {
 	var testString = "testing"
 	var testValue = newStringValue(testString, &testString)
@@ -596,6 +604,14 @@ func TestBindPFlag(t *testing.T) {
 
 	assert.Equal(t, "testing_mutate", Get("testvalue"))
 
+}
+
+func TestBindPFlagNil(t *testing.T) {
+	v := New()
+	err := v.BindPFlag("any", nil)
+	if err == nil {
+		t.Fatalf("expected error when passing nil to BindPFlag")
+	}
 }
 
 func TestBoundCaseSensitivity(t *testing.T) {


### PR DESCRIPTION
`Sub` with pflags didn't work as I expected because the key prefix wasn't checked for flags. This should allow binding pflags to behave very similar to structured configurations loaded from files.

The nil check is needed since it's put into the pflagValue* structure that never checks if the PFlag pointer is valid.

This has code partially based on #331 for b7a4909 that uses the same `flag` name & updated comment for `flag`. Though the comment isn't totally correct for this PR, but #331 IMO should be merged.

This fixes #368 & #422 