### PR TITLE
Call onConfigChange callback only if it is not nil

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -289,7 +289,9 @@ func (v *Viper) WatchConfig() {
 							if err != nil {
 								log.Println("error:", err)
 							}
-							v.onConfigChange(event)
+							if v.onConfigChange != nil {
+								v.onConfigChange(event)
+							}
 						}
 					}
 				case err := <-watcher.Errors:


### PR DESCRIPTION
I've found some discrepancy in documentation and actual behavior of the package. When viper's config file is being watched, onConfigChange callback will be called **every** time when `fsnotify` send an event. 

The problem comes from `viper.New()` where onConfigChange is not initialized and remains nil. So according to documentation:
> Optionally you can provide a function for Viper to run each time a change occurs.

optional attribute does not have default value and if user won't explicitly define callback function, it will result a SIGSEGV.

So to prevent any bugs, I've rewrite code to run callback only if it's not nil.