### PR TITLE
config need sub Viper instance List

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/viper.go
+++ b/viper.go
@@ -664,6 +664,7 @@ func (v *Viper) Sub(key string) *Viper {
 	return nil
 }
 
+//Sub list returns new Viper instance List representing a sub tree of this instance.
 func SubList(key string) []*Viper { return v.SubList(key) }
 func (v *Viper) SubList(key string) []*Viper {
 	data := v.Get(key)

--- a/viper.go
+++ b/viper.go
@@ -664,6 +664,24 @@ func (v *Viper) Sub(key string) *Viper {
 	return nil
 }
 
+func SubList(key string) []*Viper { return v.SubList(key) }
+func (v *Viper) SubList(key string) []*Viper {
+	data := v.Get(key)
+	if data == nil {
+		return nil
+	}
+	var vList []*Viper
+	if reflect.TypeOf(data).Kind() == reflect.Slice {
+		for _, item := range data.([]interface{}) {
+			subv := New()
+			subv.config = cast.ToStringMap(item)
+			vList = append(vList, subv)
+		}
+		return vList
+	}
+	return nil
+}
+
 // GetString returns the value associated with the key as a string.
 func GetString(key string) string { return v.GetString(key) }
 func (v *Viper) GetString(key string) string {


### PR DESCRIPTION
for example:
{"config": ["{"sub_config":xxx}"]}

viper.Get("config") returns [map[sub_config:xxx]]，but we hope all return data is viper, so we can use viper function to get, not map or any other struct.

Each viper instance need returns sub viper intance list which can deep traverse data.