### PR TITLE
Add global UnmarshalExact method

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -798,6 +798,7 @@ func decode(input interface{}, config *mapstructure.DecoderConfig) error {
 
 // UnmarshalExact unmarshals the config into a Struct, erroring if a field is nonexistent
 // in the destination struct.
+func UnmarshalExact(rawVal interface{}) error { return v.UnmarshalExact(rawVal) }
 func (v *Viper) UnmarshalExact(rawVal interface{}) error {
 	config := defaultDecoderConfig(rawVal)
 	config.ErrorUnused = true


### PR DESCRIPTION
There is no helper method for UnmarshalExact which calls the
corresponding method on the global viper instance.