### PR TITLE
chore(viper): adding a warning when ReadInConfig method returns an error and filename contains the extension

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1149,6 +1149,13 @@ func (v *Viper) ReadInConfig() error {
 	jww.DEBUG.Println("Reading file: ", filename)
 	file, err := afero.ReadFile(v.fs, filename)
 	if err != nil {
+		fileExt := filepath.Ext(filename)
+
+		if stringInSlice(fileExt, SupportedExts) {
+			log.Println("warning:", "Looks like you have included the file extention in the file name." +
+				"Consider using SetConfigType method instead.")
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
It's a bit confusing to have SetConfigType and SetConfigName. This PR displays a simple warning to the user if the filename contains an extension (.yaml, .json, etc.)