### PR TITLE
Allow environment variables to be set to empty string

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -334,14 +334,14 @@ func (v *Viper) mergeWithEnvPrefix(in string) string {
 // rewriting keys many things, Ex: Get('someKey') -> some_key
 // (camel case to snake case for JSON keys perhaps)
 
-// getEnv is a wrapper around os.Getenv which replaces characters in the original
+// getEnv is a wrapper around os.LookupEnv which replaces characters in the original
 // key. This allows env vars which have different keys than the config object
 // keys.
-func (v *Viper) getEnv(key string) string {
+func (v *Viper) getEnv(key string) (string, bool) {
 	if v.envKeyReplacer != nil {
 		key = v.envKeyReplacer.Replace(key)
 	}
-	return os.Getenv(key)
+	return os.LookupEnv(key)
 }
 
 // ConfigFileUsed returns the file used to populate the config registry.
@@ -568,10 +568,10 @@ func (v *Viper) isPathShadowedInFlatMap(path []string, mi interface{}) string {
 //       "foo.bar.baz" in a lower-priority map
 func (v *Viper) isPathShadowedInAutoEnv(path []string) string {
 	var parentKey string
-	var val string
+	var ok bool
 	for i := 1; i < len(path); i++ {
 		parentKey = strings.Join(path[0:i], v.keyDelim)
-		if val = v.getEnv(v.mergeWithEnvPrefix(parentKey)); val != "" {
+		if _, ok = v.getEnv(v.mergeWithEnvPrefix(parentKey)); ok {
 			return parentKey
 		}
 	}
@@ -934,7 +934,7 @@ func (v *Viper) find(lcaseKey string) interface{} {
 	if v.automaticEnvApplied {
 		// even if it hasn't been registered, if automaticEnv is used,
 		// check any Get request
-		if val = v.getEnv(v.mergeWithEnvPrefix(lcaseKey)); val != "" {
+		if val, ok := v.getEnv(v.mergeWithEnvPrefix(lcaseKey)); ok {
 			return val
 		}
 		if nested && v.isPathShadowedInAutoEnv(path) != "" {
@@ -943,7 +943,7 @@ func (v *Viper) find(lcaseKey string) interface{} {
 	}
 	envkey, exists := v.env[lcaseKey]
 	if exists {
-		if val = v.getEnv(envkey); val != "" {
+		if val, ok := v.getEnv(envkey); ok {
 			return val
 		}
 	}

--- a/viper_test.go
+++ b/viper_test.go
@@ -375,10 +375,17 @@ func TestEnv(t *testing.T) {
 	assert.Equal(t, "apple", Get("f"))
 	assert.Equal(t, "Cake", Get("name"))
 
+	os.Setenv("FOOD", "")
+
+	assert.Equal(t, "", Get("f"))
+
 	AutomaticEnv()
 
 	assert.Equal(t, "crunk", Get("name"))
 
+	os.Setenv("NAME", "")
+
+	assert.Equal(t, "", Get("name"))
 }
 
 func TestEnvPrefix(t *testing.T) {
@@ -396,9 +403,17 @@ func TestEnvPrefix(t *testing.T) {
 	assert.Equal(t, "apple", Get("f"))
 	assert.Equal(t, "Cake", Get("name"))
 
+	os.Setenv("FOO_ID", "")
+
+	assert.Equal(t, "", Get("id"))
+
 	AutomaticEnv()
 
 	assert.Equal(t, "crunk", Get("name"))
+
+	os.Setenv("FOO_NAME", "")
+
+	assert.Equal(t, "", Get("name"))
 }
 
 func TestAutoEnv(t *testing.T) {


### PR DESCRIPTION
We have a case in our application where we set a default value for a link (a string setting), but users can set it to the empty string to hide the link. This works fine through the json config, but it doesn't work if they configure their environment using environment variables.

This is because the existing code for reading environment variables is using [os.Getenv](https://golang.org/pkg/os/#Getenv) which doesn't differentiate between an unset environment variable and one set to the empty string. By changing this to use [os.LookupEnv](https://golang.org/pkg/os/#LookupEnv), we can distinguish an unset setting from an empty one.