### PR TITLE
Add a new Unset function to remove a key from viper.

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1132,6 +1132,20 @@ func (v *Viper) Set(key string, value interface{}) {
 	deepestMap[lastKey] = value
 }
 
+// Unset deletes a key from Viper.
+// Unset is case-insensitive for a key.
+func Unset(key string) { v.Unset(key, value) }
+func (v *Viper) Unset(key string) {
+	// If alias passed in, then set the proper override
+	key = v.realKey(strings.ToLower(key))
+
+	path := strings.Split(key, v.keyDelim)
+	lastKey := strings.ToLower(path[len(path)-1])
+	deepestMap := deepSearch(v.override, path[0:len(path)-1])
+
+	delete(deepestMap, lastKey)
+}
+
 // ReadInConfig will discover and load the configuration file from disk
 // and key/value stores, searching in one of the defined paths.
 func ReadInConfig() error { return v.ReadInConfig() }


### PR DESCRIPTION
In some circunstances, you want to remove a key for your config in viper, so, instead of setting the key value to nil, it's better to have a new Unset function to remove the key from the inner map.

Since this is my first PR to the project, please let me know if I need to do something else.