### PR TITLE
Support customising mapstructure.DecoderConfig for Unmarshal

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -113,6 +113,23 @@ func (fnfe ConfigFileNotFoundError) Error() string {
 	return fmt.Sprintf("Config File %q Not Found in %q", fnfe.name, fnfe.locations)
 }
 
+// A DecoderConfigOption can be passed to viper.Unmarshal to configure
+// mapstructure.DecoderConfig options
+type DecoderConfigOption func(*mapstructure.DecoderConfig)
+
+// DecodeHook returns a DecoderConfigOption which overrides the default
+// DecoderConfig.DecodeHook value, the default is:
+//
+//  mapstructure.ComposeDecodeHookFunc(
+//		mapstructure.StringToTimeDurationHookFunc(),
+//		mapstructure.StringToSliceHookFunc(","),
+//	)
+func DecodeHook(hook mapstructure.DecodeHookFunc) DecoderConfigOption {
+	return func(c *mapstructure.DecoderConfig) {
+		c.DecodeHook = hook
+	}
+}
+
 // Viper is a prioritized configuration registry. It
 // maintains a set of configuration sources, fetches
 // values to populate those, and provides them according
@@ -745,9 +762,11 @@ func (v *Viper) GetSizeInBytes(key string) uint {
 }
 
 // UnmarshalKey takes a single key and unmarshals it into a Struct.
-func UnmarshalKey(key string, rawVal interface{}) error { return v.UnmarshalKey(key, rawVal) }
-func (v *Viper) UnmarshalKey(key string, rawVal interface{}) error {
-	err := decode(v.Get(key), defaultDecoderConfig(rawVal))
+func UnmarshalKey(key string, rawVal interface{}, opts ...DecoderConfigOption) error {
+	return v.UnmarshalKey(key, rawVal, opts...)
+}
+func (v *Viper) UnmarshalKey(key string, rawVal interface{}, opts ...DecoderConfigOption) error {
+	err := decode(v.Get(key), defaultDecoderConfig(rawVal, opts...))
 
 	if err != nil {
 		return err
@@ -760,9 +779,11 @@ func (v *Viper) UnmarshalKey(key string, rawVal interface{}) error {
 
 // Unmarshal unmarshals the config into a Struct. Make sure that the tags
 // on the fields of the structure are properly set.
-func Unmarshal(rawVal interface{}) error { return v.Unmarshal(rawVal) }
-func (v *Viper) Unmarshal(rawVal interface{}) error {
-	err := decode(v.AllSettings(), defaultDecoderConfig(rawVal))
+func Unmarshal(rawVal interface{}, opts ...DecoderConfigOption) error {
+	return v.Unmarshal(rawVal, opts...)
+}
+func (v *Viper) Unmarshal(rawVal interface{}, opts ...DecoderConfigOption) error {
+	err := decode(v.AllSettings(), defaultDecoderConfig(rawVal, opts...))
 
 	if err != nil {
 		return err
@@ -775,8 +796,8 @@ func (v *Viper) Unmarshal(rawVal interface{}) error {
 
 // defaultDecoderConfig returns default mapsstructure.DecoderConfig with suppot
 // of time.Duration values & string slices
-func defaultDecoderConfig(output interface{}) *mapstructure.DecoderConfig {
-	return &mapstructure.DecoderConfig{
+func defaultDecoderConfig(output interface{}, opts ...DecoderConfigOption) *mapstructure.DecoderConfig {
+	c := &mapstructure.DecoderConfig{
 		Metadata:         nil,
 		Result:           output,
 		WeaklyTypedInput: true,
@@ -785,6 +806,10 @@ func defaultDecoderConfig(output interface{}) *mapstructure.DecoderConfig {
 			mapstructure.StringToSliceHookFunc(","),
 		),
 	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 // A wrapper around mapstructure.Decode that mimics the WeakDecode functionality


### PR DESCRIPTION
Hi

I recently ran into an issue when using `viper.Unmarshal` in-conjunction with Environment variables. I wished to pass a `json` object as a value to an Environment variable for user names and passwords that I didn't want to write to a config file, for example:

```
export MY_CONFIG_VAL={\"foo\":\"bar\",\"fizz\":\"buzz\"}
```

 Whilst `viper.GetStringMapString` would work perfectly, `Unmarshal` would fail with: 

```
* 'my_config_val' expected a map, got 'string'
```

I did some digging and saw this was failing in `mapstructure`. I saw it supported custom `DecodeHook` functions so I could write my own function to parse the value correctly, however `viper` does not support the ability to customise the `mapstructure.DecoderConfig`.

So this PR adds the following (it's worth noting this is 100% backwards compatible thanks to variadic arguments):

* Added a new `DecoderConfigOption` type allowing the user to write custom
  functions that can override the default mapstructure.DecoderConfig
  settings

* Added a new `DecodeHook` function which returns
  a `DecoderConfigOption`. This allows the user to easily set their own
  Decode hooks when Unmarshaling

* Updated Unmarshal, UnmarshalKey and defaultDecoderConfig to support variadic
  trailing `DecoderConfigOption` functions to allow for customisation of
  the default  mapstructure.DecoderConfig

* Added a test case with example usage

I look forward to your review and feedback :smile: 

p.s and thank you for this wonderful library.

**Edits: spelling**