### PR TITLE
if config type is already set, ignore file extension

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1245,7 +1245,14 @@ func (v *Viper) writeConfig(filename string, force bool) error {
 	if len(ext) <= 1 {
 		return fmt.Errorf("Filename: %s requires valid extension.", filename)
 	}
-	configType := ext[1:]
+
+	var configType string
+	if v.configType == "" {
+		configType = ext[1:]
+	} else {
+		configType = v.configType
+	}
+
 	if !stringInSlice(configType, SupportedExts) {
 		return UnsupportedConfigError(configType)
 	}


### PR DESCRIPTION
…and use the saved config type

e.g. if viper.SetConfigType("yaml") was previously called, yaml will be used as
config format, even if the file is called XXX.conf, instead of XXXX.yaml