### PR TITLE
Fixed missing f.Close() in writeConfig()

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1266,7 +1266,13 @@ func (v *Viper) writeConfig(filename string, force bool) error {
 	if err != nil {
 		return err
 	}
-	return v.marshalWriter(f, configType)
+	defer f.Close()
+
+	if err := v.marshalWriter(f, configType); err != nil {
+		return err
+	}
+
+	return f.Sync()
 }
 
 // Unmarshal a Reader into a map.


### PR DESCRIPTION
Defering can cause trouble because we're writing to the file outside the function
where the defering is registered, calling f.Sync() ensures that bytes are flushed
to disk even is Close() is called too soon.

Ref #542 