### PR TITLE
Fix example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,7 +585,7 @@ type config struct {
 
 var C config
 
-err := Unmarshal(&C)
+err := viper.Unmarshal(&C)
 if err != nil {
 	t.Fatalf("unable to decode into struct, %v", err)
 }


### PR DESCRIPTION
hello
I found example code doesn't work.

I checked with following code.

```
package main

import (
	"fmt"

	"github.com/spf13/viper"
)

// Config sample
type Config struct {
	Id int
}

func main() {
	var c *Config
	viper.Unmarshal(&c) // this work
	// Unmarshal(&c) // this doesn't work
	fmt.Println(c.Id)
}

```

Thank you.