### PR TITLE
Feature/support getting from array maps

### DIFF
--- a/viper_test.go
+++ b/viper_test.go
@@ -1400,6 +1400,39 @@ func TestParseNested(t *testing.T) {
 	assert.Equal(t, 200*time.Millisecond, items[0].Nested.Delay)
 }
 
+func TestGetMapSliceItemWithIndex(t *testing.T) {
+	type duration struct {
+		Delay time.Duration
+	}
+
+	type item struct {
+		Name   string
+		Delay  time.Duration
+		Nested duration
+	}
+
+	config := `[[parent]]
+	delay="100ms"
+	[parent.nested]
+	delay="200ms"
+	
+	[[parent]]
+	delay="200ms"
+	[parent.nested]
+	delay="400ms"
+`
+	initConfig("toml", config)
+
+	firstNestedDelay := v.GetDuration("parent[0].delay")
+
+	assert.Equal(t, 100*time.Millisecond, firstNestedDelay)
+
+	secondNestedDelay := v.GetDuration("parent[1].nested.delay")
+
+	assert.Equal(t, 400*time.Millisecond, secondNestedDelay)
+
+}
+
 func doTestCaseInsensitive(t *testing.T, typ, config string) {
 	initConfig(typ, config)
 	Set("RfD", true)

--- a/viper_test.go
+++ b/viper_test.go
@@ -1415,6 +1415,10 @@ func TestGetMapSliceItemWithIndex(t *testing.T) {
 	delay="100ms"
 	[parent.nested]
 	delay="200ms"
+	[[parent.children]]
+	delay="300ms"
+	[parent.children.nested]
+	delay="500ms"
 	
 	[[parent]]
 	delay="200ms"
@@ -1431,6 +1435,13 @@ func TestGetMapSliceItemWithIndex(t *testing.T) {
 
 	assert.Equal(t, 400*time.Millisecond, secondNestedDelay)
 
+	crhildrenDelay := v.GetDuration("parent[0].children[0].delay")
+
+	assert.Equal(t, 300*time.Millisecond, crhildrenDelay)
+
+	deepNestedDelay := v.GetDuration("parent[0].children[0].nested.delay")
+
+	assert.Equal(t, 500*time.Millisecond, deepNestedDelay)
 }
 
 func doTestCaseInsensitive(t *testing.T, typ, config string) {


### PR DESCRIPTION
Hi. 

I've stumbled on arrays of objects for some days and find out that Viper didn't supported getting parameters using index keys. This PR is an implementation proposal to add that support.

Example usage:

Config file:

```toml
[[book]]
title = "My book"
    [book.author]
    name = "Me"

[[book]]
title = "My second book"
    [book.author]
    name = "Me again"
```

We can unmarshal this structure with no problems, but there are times when we need to get some parameters that are not mapped to a struct.

```go
// ...
// initialization and config loading
// ...
var firstBookTitle = viper.GetString("book[0].title")
fmt.Println(firstBookTitle) // prints: My book

var secondBookAuthor = viper.GetString("book[1].author.name")
fmt.Println(secondBookAuthor) // prints: Me again
```
