### PR TITLE
String Array support for pflag

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -14,6 +14,7 @@ type FlagValue interface {
 	HasChanged() bool
 	Name() string
 	ValueString() string
+	ValueStringArray() []string
 	ValueType() string
 }
 
@@ -49,6 +50,11 @@ func (p pflagValue) Name() string {
 // ValueString returns the value of the flag as a string.
 func (p pflagValue) ValueString() string {
 	return p.flag.Value.String()
+}
+
+// ValueStringArray returns the value of the flag as []string.
+func (p pflagValue) ValueStringArray() []string {
+	return p.flag.Value.StringArray()
 }
 
 // ValueType returns the type of the flag as a string.

--- a/viper.go
+++ b/viper.go
@@ -731,6 +731,12 @@ func (v *Viper) GetDuration(key string) time.Duration {
 	return cast.ToDuration(v.Get(key))
 }
 
+// GetStringArray returns the value associated with the key as a slice of strings.
+func GetStringArray(key string) []string { return v.GetStringArray(key) }
+func (v *Viper) GetStringArray(key string) []string {
+	return cast.ToStringSlice(v.Get(key))
+}
+
 // GetStringSlice returns the value associated with the key as a slice of strings.
 func GetStringSlice(key string) []string { return v.GetStringSlice(key) }
 func (v *Viper) GetStringSlice(key string) []string {
@@ -955,6 +961,8 @@ func (v *Viper) find(lcaseKey string) interface{} {
 			s = strings.TrimSuffix(s, "]")
 			res, _ := readAsCSV(s)
 			return res
+		case "stringArray":
+			return flag.ValueStringArray()
 		default:
 			return flag.ValueString()
 		}
@@ -1024,6 +1032,8 @@ func (v *Viper) find(lcaseKey string) interface{} {
 			s = strings.TrimSuffix(s, "]")
 			res, _ := readAsCSV(s)
 			return res
+		case "stringArray":
+			return flag.ValueStringArray()
 		default:
 			return flag.ValueString()
 		}


### PR DESCRIPTION
This PR allows `viper` to pull an array of string values directly from `pflag` instead of having to encode/decode as CSV.  Depends on https://github.com/spf13/pflag/pull/181