### PR TITLE
SetEnvKeyReplacer(): replace concrete type "strings.Replacer" with its interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ with ENV:
  * `AutomaticEnv()`
  * `BindEnv(string...) : error`
  * `SetEnvPrefix(string)`
- * `SetEnvKeyReplacer(string...) *strings.Replacer`
+ * `SetEnvKeyReplacer(string...) *replacer`
 
 _When working with ENV variables, it’s important to recognize that Viper
 treats ENV variables as case sensitive._
@@ -212,8 +212,9 @@ time a `viper.Get` request is made. It will apply the following rules. It will
 check for a environment variable with a name matching the key uppercased and
 prefixed with the `EnvPrefix` if set.
 
-`SetEnvKeyReplacer` allows you to use a `strings.Replacer` object to rewrite Env
-keys to an extent. This is useful if you want to use `-` or something in your
+`SetEnvKeyReplacer` allows you to use a `replacer` interface to rewrite Env
+keys to an extent. The most popular implementation of the interface is
+`strings.Replacer`. This is useful if you want to use `-` or something in your
 `Get()` calls, but want your environmental variables to use `_` delimiters. An
 example of using it can be found in `viper_test.go`.
 

--- a/viper.go
+++ b/viper.go
@@ -186,7 +186,7 @@ type Viper struct {
 	envPrefix  string
 
 	automaticEnvApplied bool
-	envKeyReplacer      *strings.Replacer
+	envKeyReplacer      replacer
 
 	config         map[string]interface{}
 	override       map[string]interface{}
@@ -1084,11 +1084,16 @@ func (v *Viper) AutomaticEnv() {
 	v.automaticEnvApplied = true
 }
 
-// SetEnvKeyReplacer sets the strings.Replacer on the viper object
+// replacer is the interface that a replacement algorithm needs to implement.
+type replacer interface {
+	Replace(s string) string
+}
+
+// SetEnvKeyReplacer sets the replacer on the viper object
 // Useful for mapping an environmental variable to a key that does
 // not match it.
-func SetEnvKeyReplacer(r *strings.Replacer) { v.SetEnvKeyReplacer(r) }
-func (v *Viper) SetEnvKeyReplacer(r *strings.Replacer) {
+func SetEnvKeyReplacer(r replacer) { v.SetEnvKeyReplacer(r) }
+func (v *Viper) SetEnvKeyReplacer(r replacer) {
 	v.envKeyReplacer = r
 }
 


### PR DESCRIPTION
# Introduction
Previous implementation of [SetEnvKeyReplacer](https://github.com/spf13/viper/blob/8e194e8ad2432506b0a6dac93dd7876fca7a94a5/viper.go#L1091) has parameter `r` with type of certain struct pointer: ***strings.Replacer**.
# Problem
The implementation doesn't allow us to use custom string-replacers. For example, we can't use **LowerCamelCase**-to-**ScreamingSnakeCase** replacer: `myParamter` -> `MY_PARAMETER`
# Solution
There's an internal interface in go's std-lib: [strings.replacer](https://golang.org/src/strings/replace.go). It is the good way to standardize all string-replacers.
If **SetEnvKeyReplacer()** accepts the interface, then we might use any implementation of it.
# Notes
This PR is the solution of [the issue](https://github.com/spf13/viper/issues/569) #569