### PR TITLE
Fixed unmarshalReader not returning an error

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1329,7 +1329,9 @@ func unmarshalReader(in io.Reader, c map[string]interface{}) error {
 }
 func (v *Viper) unmarshalReader(in io.Reader, c map[string]interface{}) error {
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(in)
+	if _, err := buf.ReadFrom(in); err != nil {
+		return ConfigParseError{err}
+	}
 
 	switch strings.ToLower(v.getConfigType()) {
 	case "yaml", "yml":


### PR DESCRIPTION
Quick fix on unmarshalReader not returning an error when the input `io.Reader` returns an error. I caught that while mocking the input `io.Reader` and making the `Read` method to return an error on a unit test.