### PR TITLE
added a setting to make viper case sensitive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ _testmain.go
 
 # exclude dependencies in the `/vendor` folder
 vendor
+.idea/


### PR DESCRIPTION
In some cases it is useful to preserve the case sensitivity of keys. This change adds the option to call viper.SetCaseSensitive(true) to enable case sensitivity.

This feature is needed for example when unmarshalling a config into a map[string]interface{}, changing some of the config values and then saving it again to a file. If the keys are always lowercased, the structure of the regenerated config will be changed, which is undesirable.

Addressing #260, #293, #373