### PR TITLE
Fix failing TestBindPFlagsStringSlice

### DIFF
--- a/viper_test.go
+++ b/viper_test.go
@@ -617,7 +617,7 @@ func TestBindPFlagsStringSlice(t *testing.T) {
 		Expected []string
 		Value    string
 	}{
-		{[]string{}, ""},
+		{[]string(nil), ""},
 		{[]string{"jeden"}, "jeden"},
 		{[]string{"dwa", "trzy"}, "dwa,trzy"},
 		{[]string{"cztery", "piec , szesc"}, "cztery,\"piec , szesc\""},


### PR DESCRIPTION
After mitchelh/mapstructure has been updated, the expected test result needs to be updated to the actual returned result.

Closes: spf13/viper#579.