### PR TITLE
Only try to read configuration from regular files

### DIFF
--- a/util.go
+++ b/util.go
@@ -114,10 +114,10 @@ func absPathify(inPath string) string {
 	return ""
 }
 
-// Check if File / Directory Exists
-func exists(fs afero.Fs, path string) (bool, error) {
-	_, err := fs.Stat(path)
-	if err == nil {
+// isRegular returns true if path exists and is a regular file.
+func isRegular(fs afero.Fs, path string) (bool, error) {
+	info, err := fs.Stat(path)
+	if err == nil && info.Mode().IsRegular() {
 		return true, nil
 	}
 	if os.IsNotExist(err) {

--- a/viper.go
+++ b/viper.go
@@ -1812,7 +1812,7 @@ func (v *Viper) searchInPath(in string) (filename string) {
 	jww.DEBUG.Println("Searching for config in ", in)
 	for _, ext := range SupportedExts {
 		jww.DEBUG.Println("Checking for", filepath.Join(in, v.configName+"."+ext))
-		if b, _ := exists(v.fs, filepath.Join(in, v.configName+"."+ext)); b {
+		if b, _ := isRegular(v.fs, filepath.Join(in, v.configName+"."+ext)); b {
 			jww.DEBUG.Println("Found: ", filepath.Join(in, v.configName+"."+ext))
 			return filepath.Join(in, v.configName+"."+ext)
 		}


### PR DESCRIPTION
Before this commit, if the configuration is called `foo` and `foo` is a directory, then Viper will return an error trying to read the directory `foo` as a file and never try `foo.json`, `foo.toml`, etc.

With this commit, Viper will only try to read configuration from regular files. Non-regular files (e.g. directories, device nodes, etc.) will be ignored.