### PR TITLE
Remove AllowEmptyEnvVar from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,6 @@ with ENV:
  * `BindEnv(string...) : error`
  * `SetEnvPrefix(string)`
  * `SetEnvKeyReplacer(string...) *strings.Replacer`
-  * `AllowEmptyEnvVar(bool)`
 
 _When working with ENV variables, it’s important to recognize that Viper
 treats ENV variables as case sensitive._


### PR DESCRIPTION
The method `AllowEmptyEnvVar` no longer exists and hence shouldn't be mentioned in the documentation anymore