### PR TITLE
Adds support for merging slices

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1510,6 +1510,12 @@ func mergeMaps(
 		case map[string]interface{}:
 			jww.TRACE.Printf("merging maps")
 			mergeMaps(sv.(map[string]interface{}), ttv, nil)
+		case []interface{}:
+			jww.TRACE.Printf("merging slices")
+			tgt[tk] = append(tgt[tk].([]interface{}), sv.([]interface{})...)
+			if itgt != nil {
+				itgt[tk] = append(itgt[tk].([]interface{}), sv.([]interface{})...)
+			}
 		default:
 			jww.TRACE.Printf("setting value")
 			tgt[tk] = sv

--- a/viper_test.go
+++ b/viper_test.go
@@ -1079,6 +1079,11 @@ hello:
     - uk
     - fr
     - de
+list:
+- one
+list2:
+- name: name1
+  value: value1
 `)
 
 var yamlMergeExampleSrc = []byte(`
@@ -1088,6 +1093,14 @@ hello:
     universe:
     - mw
     - ad
+list:
+- two
+- three
+list2:
+- name: name2
+  value: value2
+- name: name3
+  value: value3
 fu: bar
 `)
 
@@ -1118,6 +1131,18 @@ func TestMergeConfig(t *testing.T) {
 		t.Fatalf("fu != \"\", = %s", fu)
 	}
 
+	if list := v.GetStringSlice("list"); len(list) != 1 {
+		t.Fatalf("len(list) != 1, = %d", len(list))
+	}
+
+	list2 := []interface{}{}
+	if err := v.UnmarshalKey("list2", &list2); err != nil {
+		t.Fatal(err)
+	}
+	if len(list2) != 1 {
+		t.Fatalf("len(list2) != 1, = %d", len(list2))
+	}
+
 	if err := v.MergeConfig(bytes.NewBuffer(yamlMergeExampleSrc)); err != nil {
 		t.Fatal(err)
 	}
@@ -1144,6 +1169,18 @@ func TestMergeConfig(t *testing.T) {
 
 	if fu := v.GetString("fu"); fu != "bar" {
 		t.Fatalf("fu != \"bar\", = %s", fu)
+	}
+
+	if list := v.GetStringSlice("list"); len(list) != 3 {
+		t.Fatalf("len(list) != 3, = %d", len(list))
+	}
+
+	list2 = []interface{}{}
+	if err := v.UnmarshalKey("list2", &list2); err != nil {
+		t.Fatal(err)
+	}
+	if len(list2) != 3 {
+		t.Fatalf("len(list2) != 3, = %d", len(list2))
 	}
 }
 


### PR DESCRIPTION
- Work allows slices to be merged by appending of src onto target

It seems odd to not have this feature when the function is called merge. I could understand the reasoning if ordering of slices was important. If this is required could implement a merge strategy interface.

Thanks for checking out the PR