### PR TITLE
Fix indentation for yamlStringSettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,11 +630,11 @@ import (
 
 func yamlStringSettings() string {
     c := viper.AllSettings()
-	bs, err := yaml.Marshal(c)
-	if err != nil {
+    bs, err := yaml.Marshal(c)
+    if err != nil {
         t.Fatalf("unable to marshal config to YAML: %v", err)
     }
-	return string(bs)
+    return string(bs)
 }
 ```
 


### PR DESCRIPTION
The indentation seemed messed up and didn't read well. This change fixes it.