### PR TITLE
New merge strategy feature

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -986,6 +986,11 @@ func (v *Viper) BindEnv(input ...string) error {
 	return nil
 }
 
+func SetStrategy(strategies ...MergeStrategy) { v.SetStrategy(strategies...) }
+func (v *Viper) SetStrategy(strategies ...MergeStrategy) {
+	v.mergeStrategies = strategies
+}
+
 // Given a key, find the value.
 // Viper will check in the following order:
 // flag, env, config file, key/value store, default.

--- a/viper_test.go
+++ b/viper_test.go
@@ -1332,6 +1332,26 @@ func TestMergeMapsSliceWithStategy(t *testing.T) {
 	}
 }
 
+func TestMergeMultipleConfigSlicesWithStrategy(t *testing.T) {
+	config1 := []byte(`
+sliceData:
+- one
+- two`)
+	config2 := []byte(`
+sliceData:
+- three`)
+
+	v := New()
+	v.SetStrategy(SliceAppendStrategy())
+	v.SetConfigType("yaml")
+	v.MergeConfig(bytes.NewReader(config1))
+	v.MergeConfig(bytes.NewReader(config2))
+	val := v.GetStringSlice("sliceData")
+	if !reflect.DeepEqual(val, []string{"one", "two", "three"}) {
+		t.Fatalf("unexpected key value wanted %s got %s", []string{"one", "two", "three"}, val)
+	}
+}
+
 func TestUnmarshalingWithAliases(t *testing.T) {
 	v := New()
 	v.SetDefault("ID", 1)


### PR DESCRIPTION
This PR is attempting to add basic building blocks for controlling how certain type are merged in the config map. It doesn't change any behavior by default but allows the user to control the process if they want.

I did this work to get append functionality for merging maps that have slices.

Cheers for checking out the PR