### PR TITLE
[doc] Fix indentation of yamlStringSettings example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,11 +630,11 @@ import (
 
 func yamlStringSettings() string {
     c := viper.AllSettings()
-	bs, err := yaml.Marshal(c)
-	if err != nil {
+    bs, err := yaml.Marshal(c)
+    if err != nil {
         t.Fatalf("unable to marshal config to YAML: %v", err)
     }
-	return string(bs)
+    return string(bs)
 }
 ```
 


### PR DESCRIPTION
Before fix:

![screenshot from 2019-01-29 08-54-20](https://user-images.githubusercontent.com/2655598/51892900-93556780-23a3-11e9-962b-27d5d377b816.png)

After fix:

![screenshot from 2019-01-29 08-54-37](https://user-images.githubusercontent.com/2655598/51892904-981a1b80-23a3-11e9-9a63-ba74c047656c.png)
