### PR TITLE
Add setters for key delimiter

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1768,7 +1768,7 @@ func (v *Viper) SetConfigType(in string) {
 // SetKeyDelim set the delimiter string used to separate key values
 // returned by AllKeys(). This is useful if you need to allow for
 // the '.' character in key names.
-func SetKeyDelim(delim string) { v.keyDelim = delim }
+func SetKeyDelim(delim string)            { v.keyDelim = delim }
 func (v *Viper) SetKeyDelim(delim string) { v.keyDelim = delim }
 
 func (v *Viper) getConfigType() string {

--- a/viper.go
+++ b/viper.go
@@ -1765,6 +1765,12 @@ func (v *Viper) SetConfigType(in string) {
 	}
 }
 
+// SetKeyDelim set the delimiter string used to separate key values
+// returned by AllKeys(). This is useful if you need to allow for
+// the '.' character in key names.
+func SetKeyDelim(delim string) { v.keyDelim = delim }
+func (v *Viper) SetKeyDelim(delim string) { v.keyDelim = delim }
+
 func (v *Viper) getConfigType() string {
 	if v.configType != "" {
 		return v.configType


### PR DESCRIPTION
As discussed in #324, the use of the dot delimiter for keys can cause issues when keys themselves also contain dots. To get around this issue, I propose we add setters that can be used to change the delimiter for cases when it is required that dots are allowed in key values.