### PR TITLE
Warn when a yaml file has duplicated keys

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1346,8 +1346,12 @@ func (v *Viper) unmarshalReader(in io.Reader, c map[string]interface{}) error {
 
 	switch strings.ToLower(v.getConfigType()) {
 	case "yaml", "yml":
-		if err := yaml.Unmarshal(buf.Bytes(), &c); err != nil {
-			return ConfigParseError{err}
+		// Try UnmarshalStrict first, so we can warn about duplicated keys
+		if strictErr := yaml.UnmarshalStrict(buf.Bytes(), &c); strictErr != nil {
+			if err := yaml.Unmarshal(buf.Bytes(), &c); err != nil {
+				return ConfigParseError{err}
+			}
+			log.Printf("warning reading config file: %v\n", strictErr)
 		}
 
 	case "json":


### PR DESCRIPTION
Try using `UnmarshalStrict`, if it fails, print the errors as a warning and try again with plain `Unmarshal`.

Errors look this way:
```
2019/03/26 15:11:33 warning reading config file: yaml: unmarshal errors:
  line 6: key "api_key" already set in map
```