### PR TITLE
travis: ensure dependencies are encoded in go.mod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,12 @@ matrix:
 
 script:
   - go install ./...
+
+  # Ensure no dependencies were added without encoding them in go.mod/go.sum.
+  - go mod tidy
+  - git diff go.mod | tee /dev/stderr | (! read)
+  - git diff go.sum | tee /dev/stderr | (! read)
+
   - diff -u <(echo -n) <(gofmt -d .)
   - go test -v ./...
 


### PR DESCRIPTION
Currently a user can add new deps in *.go files that do not exist in the
go.mod/go.sum. This commit adds a small check in CI to ensure that no new
deps were added that aren't in the go.mod/go.sum.