### PR TITLE
Add GetIntSlice helper method

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ The following functions and methods exist:
  * `GetBool(key string) : bool`
  * `GetFloat64(key string) : float64`
  * `GetInt(key string) : int`
+ * `GetIntSlice(key string) : []int`
  * `GetString(key string) : string`
  * `GetStringMap(key string) : map[string]interface{}`
  * `GetStringMapString(key string) : map[string]string`

--- a/viper.go
+++ b/viper.go
@@ -797,7 +797,7 @@ func (v *Viper) GetDuration(key string) time.Duration {
 	return cast.ToDuration(v.Get(key))
 }
 
-// GetIntSlice returns the value associated with the key as a slice of strings.
+// GetIntSlice returns the value associated with the key as a slice of int values.
 func GetIntSlice(key string) []int { return v.GetIntSlice(key) }
 func (v *Viper) GetIntSlice(key string) []int {
 	return cast.ToIntSlice(v.Get(key))

--- a/viper.go
+++ b/viper.go
@@ -797,6 +797,12 @@ func (v *Viper) GetDuration(key string) time.Duration {
 	return cast.ToDuration(v.Get(key))
 }
 
+// GetIntSlice returns the value associated with the key as a slice of strings.
+func GetIntSlice(key string) []int { return v.GetIntSlice(key) }
+func (v *Viper) GetIntSlice(key string) []int {
+	return cast.ToIntSlice(v.Get(key))
+}
+
 // GetStringSlice returns the value associated with the key as a slice of strings.
 func GetStringSlice(key string) []string { return v.GetStringSlice(key) }
 func (v *Viper) GetStringSlice(key string) []string {

--- a/viper_test.go
+++ b/viper_test.go
@@ -1262,6 +1262,9 @@ hello:
     universe:
     - mw
     - ad
+    ints:
+    - 1
+    - 2
 fu: bar
 `)
 
@@ -1328,6 +1331,10 @@ func TestMergeConfig(t *testing.T) {
 		t.Fatalf("len(universe) != 2, = %d", len(universe))
 	}
 
+	if ints := v.GetIntSlice("hello.ints"); len(ints) != 2 {
+		t.Fatalf("len(ints) != 2, = %d", len(ints))
+	}
+
 	if fu := v.GetString("fu"); fu != "bar" {
 		t.Fatalf("fu != \"bar\", = %s", fu)
 	}
@@ -1366,6 +1373,10 @@ func TestMergeConfigNoMerge(t *testing.T) {
 
 	if universe := v.GetStringSlice("hello.universe"); len(universe) != 2 {
 		t.Fatalf("len(universe) != 2, = %d", len(universe))
+	}
+
+	if ints := v.GetIntSlice("hello.ints"); len(ints) != 2 {
+		t.Fatalf("len(ints) != 2, = %d", len(ints))
 	}
 
 	if fu := v.GetString("fu"); fu != "bar" {


### PR DESCRIPTION
Kinda follow up this PR : https://github.com/spf13/viper/pull/637

Adds a simple `GetIntSlice` methods that enables parsing int slices from config the same way `GetStringSlice` works.