### PR TITLE
Support config files with no extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ if err != nil { // Handle errors reading the config file
 }
 ```
 
+*NOTE:* You can also have a file without an extension and specify the format programmaticaly. For those configuration files that lie in the home of the user without any extension like `.bashrc`
+
 ### Writing Config Files
 
 Reading from config files is useful, but at times you want to store all modifications made at run time.

--- a/viper.go
+++ b/viper.go
@@ -1863,6 +1863,10 @@ func (v *Viper) getConfigFile() (string, error) {
 
 func (v *Viper) searchInPath(in string) (filename string) {
 	jww.DEBUG.Println("Searching for config in ", in)
+	if b, _ := exists(v.fs, filepath.Join(in, v.configName)); b {
+		return filepath.Join(in, v.configName)
+	}
+
 	for _, ext := range SupportedExts {
 		jww.DEBUG.Println("Checking for", filepath.Join(in, v.configName+"."+ext))
 		if b, _ := exists(v.fs, filepath.Join(in, v.configName+"."+ext)); b {

--- a/viper.go
+++ b/viper.go
@@ -1873,16 +1873,16 @@ func (v *Viper) getConfigFile() (string, error) {
 
 func (v *Viper) searchInPath(in string) (filename string) {
 	jww.DEBUG.Println("Searching for config in ", in)
-	if b, _ := exists(v.fs, filepath.Join(in, v.configName)); b {
-		return filepath.Join(in, v.configName)
-	}
-
 	for _, ext := range SupportedExts {
 		jww.DEBUG.Println("Checking for", filepath.Join(in, v.configName+"."+ext))
 		if b, _ := exists(v.fs, filepath.Join(in, v.configName+"."+ext)); b {
 			jww.DEBUG.Println("Found: ", filepath.Join(in, v.configName+"."+ext))
 			return filepath.Join(in, v.configName+"."+ext)
 		}
+	}
+
+	if b, _ := exists(v.fs, filepath.Join(in, v.configName)); b {
+		return filepath.Join(in, v.configName)
 	}
 
 	return ""

--- a/viper_test.go
+++ b/viper_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"sort"
@@ -270,6 +271,22 @@ func TestBasics(t *testing.T) {
 	SetConfigFile("/tmp/config.yaml")
 	filename, err := v.getConfigFile()
 	assert.Equal(t, "/tmp/config.yaml", filename)
+	assert.NoError(t, err)
+}
+
+func TestSearchInPath(t *testing.T) {
+	filename := ".dotfilenoext"
+	path := "/tmp"
+	file := filepath.Join(path, filename)
+	SetConfigName(filename)
+	AddConfigPath(path)
+	_, createErr := v.fs.Create(file)
+	defer func() {
+		_ = v.fs.Remove(file)
+	}()
+	assert.NoError(t, createErr)
+	filename, err := v.getConfigFile()
+	assert.Equal(t, file, filename)
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
Support config files with no extension.

Closes: spf13/viper#390
Closes: spf13/viper#336

Similar to https://github.com/spf13/viper/pull/357/files which appears to have been forgotten. 

Difference is: attempt a no extension right away instead of messing with the extension append and iterating through the extensions.