### PR TITLE
Demonstrate uppercase bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.0.0
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.2.2
+	github.com/subosito/gotenv v1.1.1
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
 	github.com/ugorji/go v1.1.4 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/subosito/gotenv v1.1.1 h1:TWxckSF6WVKWbo2M3tMqCtWa9NFUgqM1SSynxmYONOI=
+github.com/subosito/gotenv v1.1.1/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc/wtumK+WB441p7ynQJzVuNRJiqddSIE3IlSEQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4 h1:j4s+tAvLfL3bZyefP2SEWmhBzmuIlH/eqNuPdFPgngw=

--- a/viper_test.go
+++ b/viper_test.go
@@ -39,7 +39,7 @@ hobbies:
 - go
 clothing:
   jacket: leather
-  trousers: denim
+  TROUSERS: denim
   pants:
     size: large
 age: 35
@@ -295,7 +295,7 @@ func TestUnmarshaling(t *testing.T) {
 	assert.False(t, InConfig("state"))
 	assert.Equal(t, "steve", Get("name"))
 	assert.Equal(t, []interface{}{"skateboarding", "snowboarding", "go"}, Get("hobbies"))
-	assert.Equal(t, map[string]interface{}{"jacket": "leather", "trousers": "denim", "pants": map[string]interface{}{"size": "large"}}, Get("clothing"))
+	assert.Equal(t, map[string]interface{}{"jacket": "leather", "TROUSERS": "denim", "pants": map[string]interface{}{"size": "large"}}, Get("clothing"))
 	assert.Equal(t, 35, Get("age"))
 }
 
@@ -491,11 +491,11 @@ func TestSetEnvKeyReplacer(t *testing.T) {
 func TestAllKeys(t *testing.T) {
 	initConfigs()
 
-	ks := sort.StringSlice{"title", "newkey", "owner.organization", "owner.dob", "owner.bio", "name", "beard", "ppu", "batters.batter", "hobbies", "clothing.jacket", "clothing.trousers", "clothing.pants.size", "age", "hacker", "id", "type", "eyes", "p_id", "p_ppu", "p_batters.batter.type", "p_type", "p_name", "foos",
+	ks := sort.StringSlice{"title", "newkey", "owner.organization", "owner.dob", "owner.bio", "name", "beard", "ppu", "batters.batter", "hobbies", "clothing.jacket", "clothing.TROUSERS", "clothing.pants.size", "age", "hacker", "id", "type", "eyes", "p_id", "p_ppu", "p_batters.batter.type", "p_type", "p_name", "foos",
 		"title_dotenv", "type_dotenv", "name_dotenv",
 	}
 	dob, _ := time.Parse(time.RFC3339, "1979-05-27T07:32:00Z")
-	all := map[string]interface{}{"owner": map[string]interface{}{"organization": "MongoDB", "bio": "MongoDB Chief Developer Advocate & Hacker at Large", "dob": dob}, "title": "TOML Example", "ppu": 0.55, "eyes": "brown", "clothing": map[string]interface{}{"trousers": "denim", "jacket": "leather", "pants": map[string]interface{}{"size": "large"}}, "id": "0001", "batters": map[string]interface{}{"batter": []interface{}{map[string]interface{}{"type": "Regular"}, map[string]interface{}{"type": "Chocolate"}, map[string]interface{}{"type": "Blueberry"}, map[string]interface{}{"type": "Devil's Food"}}}, "hacker": true, "beard": true, "hobbies": []interface{}{"skateboarding", "snowboarding", "go"}, "age": 35, "type": "donut", "newkey": "remote", "name": "Cake", "p_id": "0001", "p_ppu": "0.55", "p_name": "Cake", "p_batters": map[string]interface{}{"batter": map[string]interface{}{"type": "Regular"}}, "p_type": "donut", "foos": []map[string]interface{}{map[string]interface{}{"foo": []map[string]interface{}{map[string]interface{}{"key": 1}, map[string]interface{}{"key": 2}, map[string]interface{}{"key": 3}, map[string]interface{}{"key": 4}}}}, "title_dotenv": "DotEnv Example", "type_dotenv": "donut", "name_dotenv": "Cake"}
+	all := map[string]interface{}{"owner": map[string]interface{}{"organization": "MongoDB", "bio": "MongoDB Chief Developer Advocate & Hacker at Large", "dob": dob}, "title": "TOML Example", "ppu": 0.55, "eyes": "brown", "clothing": map[string]interface{}{"TROUSERS": "denim", "jacket": "leather", "pants": map[string]interface{}{"size": "large"}}, "id": "0001", "batters": map[string]interface{}{"batter": []interface{}{map[string]interface{}{"type": "Regular"}, map[string]interface{}{"type": "Chocolate"}, map[string]interface{}{"type": "Blueberry"}, map[string]interface{}{"type": "Devil's Food"}}}, "hacker": true, "beard": true, "hobbies": []interface{}{"skateboarding", "snowboarding", "go"}, "age": 35, "type": "donut", "newkey": "remote", "name": "Cake", "p_id": "0001", "p_ppu": "0.55", "p_name": "Cake", "p_batters": map[string]interface{}{"batter": map[string]interface{}{"type": "Regular"}}, "p_type": "donut", "foos": []map[string]interface{}{map[string]interface{}{"foo": []map[string]interface{}{map[string]interface{}{"key": 1}, map[string]interface{}{"key": 2}, map[string]interface{}{"key": 3}, map[string]interface{}{"key": 4}}}}, "title_dotenv": "DotEnv Example", "type_dotenv": "donut", "name_dotenv": "Cake"}
 
 	allkeys := sort.StringSlice(AllKeys())
 	allkeys.Sort()
@@ -878,14 +878,14 @@ func TestFindsNestedKeys(t *testing.T) {
 		"ppu":       0.55,
 		"clothing": map[string]interface{}{
 			"jacket":   "leather",
-			"trousers": "denim",
+			"TROUSERS": "denim",
 			"pants": map[string]interface{}{
 				"size": "large",
 			},
 		},
 		"clothing.jacket":     "leather",
 		"clothing.pants.size": "large",
-		"clothing.trousers":   "denim",
+		"clothing.TROUSERS":   "denim",
 		"owner.dob":           dob,
 		"beard":               true,
 		"foos": []map[string]interface{}{
@@ -925,7 +925,7 @@ func TestReadBufConfig(t *testing.T) {
 	assert.False(t, v.InConfig("state"))
 	assert.Equal(t, "steve", v.Get("name"))
 	assert.Equal(t, []interface{}{"skateboarding", "snowboarding", "go"}, v.Get("hobbies"))
-	assert.Equal(t, map[string]interface{}{"jacket": "leather", "trousers": "denim", "pants": map[string]interface{}{"size": "large"}}, v.Get("clothing"))
+	assert.Equal(t, map[string]interface{}{"jacket": "leather", "TROUSERS": "denim", "pants": map[string]interface{}{"size": "large"}}, v.Get("clothing"))
 	assert.Equal(t, 35, v.Get("age"))
 }
 
@@ -1212,7 +1212,7 @@ clothing:
   jacket: leather
   pants:
     size: large
-  trousers: denim
+  TROUSERS: denim
 eyes: brown
 hacker: true
 hobbies:
@@ -1465,7 +1465,7 @@ func TestShadowedNestedValue(t *testing.T) {
 	config := `name: steve
 clothing:
   jacket: leather
-  trousers: denim
+  TROUSERS: denim
   pants:
     size: large
 `


### PR DESCRIPTION
In #373 it's noted that the keys are automatically converted to lower case when it shouldn't.

This PR just demonstrates it converting one YAML key to upper case in the test suite. Running the tests demonstrate the key is transformed.

```shell
Running tool: /usr/local/bin/go test -timeout 30s github.com/spf13/viper -run ^(TestBasics|TestDefault|TestUnmarshaling|TestUnmarshalExact|TestOverrides|TestDefaultPost|TestAliases|TestAliasInConfigFile|TestYML|TestJSON|TestProperties|TestTOML|TestDotEnv|TestHCL|TestRemotePrecedence|TestEnv|TestEmptyEnv|TestEmptyEnv_Allowed|TestEnvPrefix|TestAutoEnv|TestAutoEnvWithPrefix|TestSetEnvKeyReplacer|TestAllKeys|TestAllKeysWithEnv|TestAliasesOfAliases|TestRecursiveAliases|TestUnmarshal|TestUnmarshalWithDecoderOptions|TestBindPFlags|TestBindPFlagsStringSlice|TestBindPFlagsIntSlice|TestBindPFlag|TestBoundCaseSensitivity|TestSizeInBytes|TestFindsNestedKeys|TestReadBufConfig|TestIsSet|TestDirsSearch|TestWrongDirsSearchNotFound|TestWrongDirsSearchNotFoundForMerge|TestSub|TestWriteConfigHCL|TestWriteConfigJson|TestWriteConfigProperties|TestWriteConfigTOML|TestWriteConfigDotEnv|TestWriteConfigYAML|TestMergeConfig|TestMergeConfigNoMerge|TestMergeConfigMap|TestUnmarshalingWithAliases|TestSetConfigNameClearsFileCache|TestShadowedNestedValue|TestDotParameter|TestCaseInsensitive|TestCaseInsensitiveSet|TestParseNested|TestWatchFile)$

--- FAIL: TestUnmarshaling (0.00s)
    /private/tmp/viper/viper_test.go:298: 
        	Error Trace:	viper_test.go:298
        	Error:      	Not equal: 
        	            	expected: map[string]interface {}{"TROUSERS":"denim", "jacket":"leather", "pants":map[string]interface {}{"size":"large"}}
        	            	actual  : map[string]interface {}{"jacket":"leather", "pants":map[string]interface {}{"size":"large"}, "trousers":"denim"}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,3 +1,2 @@
        	            	 (map[string]interface {}) (len=3) {
        	            	- (string) (len=8) "TROUSERS": (string) (len=5) "denim",
        	            	  (string) (len=6) "jacket": (string) (len=7) "leather",
        	            	@@ -5,3 +4,4 @@
        	            	   (string) (len=4) "size": (string) (len=5) "large"
        	            	- }
        	            	+ },
        	            	+ (string) (len=8) "trousers": (string) (len=5) "denim"
        	            	 }
        	Test:       	TestUnmarshaling
--- FAIL: TestAllKeys (0.00s)
    /private/tmp/viper/viper_test.go:504: 
        	Error Trace:	viper_test.go:504
        	Error:      	Not equal: 
        	            	expected: sort.StringSlice{"age", "batters.batter", "beard", "clothing.TROUSERS", "clothing.jacket", "clothing.pants.size", "eyes", "foos", "hacker", "hobbies", "id", "name", "name_dotenv", "newkey", "owner.bio", "owner.dob", "owner.organization", "p_batters.batter.type", "p_id", "p_name", "p_ppu", "p_type", "ppu", "title", "title_dotenv", "type", "type_dotenv"}
        	            	actual  : sort.StringSlice{"age", "batters.batter", "beard", "clothing.jacket", "clothing.pants.size", "clothing.trousers", "eyes", "foos", "hacker", "hobbies", "id", "name", "name_dotenv", "newkey", "owner.bio", "owner.dob", "owner.organization", "p_batters.batter.type", "p_id", "p_name", "p_ppu", "p_type", "ppu", "title", "title_dotenv", "type", "type_dotenv"}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -4,5 +4,5 @@
        	            	  (string) (len=5) "beard",
        	            	- (string) (len=17) "clothing.TROUSERS",
        	            	  (string) (len=15) "clothing.jacket",
        	            	  (string) (len=19) "clothing.pants.size",
        	            	+ (string) (len=17) "clothing.trousers",
        	            	  (string) (len=4) "eyes",
        	Test:       	TestAllKeys
    /private/tmp/viper/viper_test.go:505: 
        	Error Trace:	viper_test.go:505
        	Error:      	Not equal: 
        	            	expected: map[string]interface {}{"age":35, "batters":map[string]interface {}{"batter":[]interface {}{map[string]interface {}{"type":"Regular"}, map[string]interface {}{"type":"Chocolate"}, map[string]interface {}{"type":"Blueberry"}, map[string]interface {}{"type":"Devil's Food"}}}, "beard":true, "clothing":map[string]interface {}{"TROUSERS":"denim", "jacket":"leather", "pants":map[string]interface {}{"size":"large"}}, "eyes":"brown", "foos":[]map[string]interface {}{map[string]interface {}{"foo":[]map[string]interface {}{map[string]interface {}{"key":1}, map[string]interface {}{"key":2}, map[string]interface {}{"key":3}, map[string]interface {}{"key":4}}}}, "hacker":true, "hobbies":[]interface {}{"skateboarding", "snowboarding", "go"}, "id":"0001", "name":"Cake", "name_dotenv":"Cake", "newkey":"remote", "owner":map[string]interface {}{"bio":"MongoDB Chief Developer Advocate & Hacker at Large", "dob":time.Time{wall:0x0, ext:62432235120, loc:(*time.Location)(nil)}, "organization":"MongoDB"}, "p_batters":map[string]interface {}{"batter":map[string]interface {}{"type":"Regular"}}, "p_id":"0001", "p_name":"Cake", "p_ppu":"0.55", "p_type":"donut", "ppu":0.55, "title":"TOML Example", "title_dotenv":"DotEnv Example", "type":"donut", "type_dotenv":"donut"}
        	            	actual  : map[string]interface {}{"age":35, "batters":map[string]interface {}{"batter":[]interface {}{map[string]interface {}{"type":"Regular"}, map[string]interface {}{"type":"Chocolate"}, map[string]interface {}{"type":"Blueberry"}, map[string]interface {}{"type":"Devil's Food"}}}, "beard":true, "clothing":map[string]interface {}{"jacket":"leather", "pants":map[string]interface {}{"size":"large"}, "trousers":"denim"}, "eyes":"brown", "foos":[]map[string]interface {}{map[string]interface {}{"foo":[]map[string]interface {}{map[string]interface {}{"key":1}, map[string]interface {}{"key":2}, map[string]interface {}{"key":3}, map[string]interface {}{"key":4}}}}, "hacker":true, "hobbies":[]interface {}{"skateboarding", "snowboarding", "go"}, "id":"0001", "name":"Cake", "name_dotenv":"Cake", "newkey":"remote", "owner":map[string]interface {}{"bio":"MongoDB Chief Developer Advocate & Hacker at Large", "dob":time.Time{wall:0x0, ext:62432235120, loc:(*time.Location)(nil)}, "organization":"MongoDB"}, "p_batters":map[string]interface {}{"batter":map[string]interface {}{"type":"Regular"}}, "p_id":"0001", "p_name":"Cake", "p_ppu":"0.55", "p_type":"donut", "ppu":0.55, "title":"TOML Example", "title_dotenv":"DotEnv Example", "type":"donut", "type_dotenv":"donut"}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -20,3 +20,2 @@
        	            	  (string) (len=8) "clothing": (map[string]interface {}) (len=3) {
        	            	-  (string) (len=8) "TROUSERS": (string) (len=5) "denim",
        	            	   (string) (len=6) "jacket": (string) (len=7) "leather",
        	            	@@ -24,3 +23,4 @@
        	            	    (string) (len=4) "size": (string) (len=5) "large"
        	            	-  }
        	            	+  },
        	            	+  (string) (len=8) "trousers": (string) (len=5) "denim"
        	            	  },
        	Test:       	TestAllKeys
--- FAIL: TestFindsNestedKeys (0.00s)
    /private/tmp/viper/viper_test.go:913: 
        	Error Trace:	viper_test.go:913
        	Error:      	Not equal: 
        	            	expected: map[string]interface {}{"TROUSERS":"denim", "jacket":"leather", "pants":map[string]interface {}{"size":"large"}}
        	            	actual  : map[string]interface {}{"jacket":"leather", "pants":map[string]interface {}{"size":"large"}, "trousers":"denim"}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,3 +1,2 @@
        	            	 (map[string]interface {}) (len=3) {
        	            	- (string) (len=8) "TROUSERS": (string) (len=5) "denim",
        	            	  (string) (len=6) "jacket": (string) (len=7) "leather",
        	            	@@ -5,3 +4,4 @@
        	            	   (string) (len=4) "size": (string) (len=5) "large"
        	            	- }
        	            	+ },
        	            	+ (string) (len=8) "trousers": (string) (len=5) "denim"
        	            	 }
        	Test:       	TestFindsNestedKeys
--- FAIL: TestReadBufConfig (0.00s)
    /private/tmp/viper/viper_test.go:922: [eyes beard hacker name hobbies clothing.jacket age clothing.trousers clothing.pants.size]
    /private/tmp/viper/viper_test.go:928: 
        	Error Trace:	viper_test.go:928
        	Error:      	Not equal: 
        	            	expected: map[string]interface {}{"TROUSERS":"denim", "jacket":"leather", "pants":map[string]interface {}{"size":"large"}}
        	            	actual  : map[string]interface {}{"jacket":"leather", "pants":map[string]interface {}{"size":"large"}, "trousers":"denim"}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,3 +1,2 @@
        	            	 (map[string]interface {}) (len=3) {
        	            	- (string) (len=8) "TROUSERS": (string) (len=5) "denim",
        	            	  (string) (len=6) "jacket": (string) (len=7) "leather",
        	            	@@ -5,3 +4,4 @@
        	            	   (string) (len=4) "size": (string) (len=5) "large"
        	            	- }
        	            	+ },
        	            	+ (string) (len=8) "trousers": (string) (len=5) "denim"
        	            	 }
        	Test:       	TestReadBufConfig
--- FAIL: TestWriteConfigYAML (0.00s)
    /private/tmp/viper/viper_test.go:1242: 
        	Error Trace:	viper_test.go:1242
        	Error:      	Not equal: 
        	            	expected: []byte{0x61, 0x67, 0x65, 0x3a, 0x20, 0x33, 0x35, 0xa, 0x62, 0x65, 0x61, 0x72, 0x64, 0x3a, 0x20, 0x74, 0x72, 0x75, 0x65, 0xa, 0x63, 0x6c, 0x6f, 0x74, 0x68, 0x69, 0x6e, 0x67, 0x3a, 0xa, 0x20, 0x20, 0x6a, 0x61, 0x63, 0x6b, 0x65, 0x74, 0x3a, 0x20, 0x6c, 0x65, 0x61, 0x74, 0x68, 0x65, 0x72, 0xa, 0x20, 0x20, 0x70, 0x61, 0x6e, 0x74, 0x73, 0x3a, 0xa, 0x20, 0x20, 0x20, 0x20, 0x73, 0x69, 0x7a, 0x65, 0x3a, 0x20, 0x6c, 0x61, 0x72, 0x67, 0x65, 0xa, 0x20, 0x20, 0x54, 0x52, 0x4f, 0x55, 0x53, 0x45, 0x52, 0x53, 0x3a, 0x20, 0x64, 0x65, 0x6e, 0x69, 0x6d, 0xa, 0x65, 0x79, 0x65, 0x73, 0x3a, 0x20, 0x62, 0x72, 0x6f, 0x77, 0x6e, 0xa, 0x68, 0x61, 0x63, 0x6b, 0x65, 0x72, 0x3a, 0x20, 0x74, 0x72, 0x75, 0x65, 0xa, 0x68, 0x6f, 0x62, 0x62, 0x69, 0x65, 0x73, 0x3a, 0xa, 0x2d, 0x20, 0x73, 0x6b, 0x61, 0x74, 0x65, 0x62, 0x6f, 0x61, 0x72, 0x64, 0x69, 0x6e, 0x67, 0xa, 0x2d, 0x20, 0x73, 0x6e, 0x6f, 0x77, 0x62, 0x6f, 0x61, 0x72, 0x64, 0x69, 0x6e, 0x67, 0xa, 0x2d, 0x20, 0x67, 0x6f, 0xa, 0x6e, 0x61, 0x6d, 0x65, 0x3a, 0x20, 0x73, 0x74, 0x65, 0x76, 0x65, 0xa}
        	            	actual  : []byte{0x61, 0x67, 0x65, 0x3a, 0x20, 0x33, 0x35, 0xa, 0x62, 0x65, 0x61, 0x72, 0x64, 0x3a, 0x20, 0x74, 0x72, 0x75, 0x65, 0xa, 0x63, 0x6c, 0x6f, 0x74, 0x68, 0x69, 0x6e, 0x67, 0x3a, 0xa, 0x20, 0x20, 0x6a, 0x61, 0x63, 0x6b, 0x65, 0x74, 0x3a, 0x20, 0x6c, 0x65, 0x61, 0x74, 0x68, 0x65, 0x72, 0xa, 0x20, 0x20, 0x70, 0x61, 0x6e, 0x74, 0x73, 0x3a, 0xa, 0x20, 0x20, 0x20, 0x20, 0x73, 0x69, 0x7a, 0x65, 0x3a, 0x20, 0x6c, 0x61, 0x72, 0x67, 0x65, 0xa, 0x20, 0x20, 0x74, 0x72, 0x6f, 0x75, 0x73, 0x65, 0x72, 0x73, 0x3a, 0x20, 0x64, 0x65, 0x6e, 0x69, 0x6d, 0xa, 0x65, 0x79, 0x65, 0x73, 0x3a, 0x20, 0x62, 0x72, 0x6f, 0x77, 0x6e, 0xa, 0x68, 0x61, 0x63, 0x6b, 0x65, 0x72, 0x3a, 0x20, 0x74, 0x72, 0x75, 0x65, 0xa, 0x68, 0x6f, 0x62, 0x62, 0x69, 0x65, 0x73, 0x3a, 0xa, 0x2d, 0x20, 0x73, 0x6b, 0x61, 0x74, 0x65, 0x62, 0x6f, 0x61, 0x72, 0x64, 0x69, 0x6e, 0x67, 0xa, 0x2d, 0x20, 0x73, 0x6e, 0x6f, 0x77, 0x62, 0x6f, 0x61, 0x72, 0x64, 0x69, 0x6e, 0x67, 0xa, 0x2d, 0x20, 0x67, 0x6f, 0xa, 0x6e, 0x61, 0x6d, 0x65, 0x3a, 0x20, 0x73, 0x74, 0x65, 0x76, 0x65, 0xa}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -5,4 +5,4 @@
        	            	  00000030  20 20 70 61 6e 74 73 3a  0a 20 20 20 20 73 69 7a  |  pants:.    siz|
        	            	- 00000040  65 3a 20 6c 61 72 67 65  0a 20 20 54 52 4f 55 53  |e: large.  TROUS|
        	            	- 00000050  45 52 53 3a 20 64 65 6e  69 6d 0a 65 79 65 73 3a  |ERS: denim.eyes:|
        	            	+ 00000040  65 3a 20 6c 61 72 67 65  0a 20 20 74 72 6f 75 73  |e: large.  trous|
        	            	+ 00000050  65 72 73 3a 20 64 65 6e  69 6d 0a 65 79 65 73 3a  |ers: denim.eyes:|
        	            	  00000060  20 62 72 6f 77 6e 0a 68  61 63 6b 65 72 3a 20 74  | brown.hacker: t|
        	Test:       	TestWriteConfigYAML
FAIL
FAIL	github.com/spf13/viper	0.082s
Error: Tests failed.
```