### PR TITLE
Fix Dropped Errors

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -77,11 +77,12 @@ func getConfigManager(rp viper.RemoteProvider) (crypt.ConfigManager, error) {
 	var err error
 
 	if rp.SecretKeyring() != "" {
-		kr, err := os.Open(rp.SecretKeyring())
-		defer kr.Close()
+		var kr *os.File
+		kr, err = os.Open(rp.SecretKeyring())
 		if err != nil {
 			return nil, err
 		}
+		defer kr.Close()
 		if rp.Provider() == "etcd" {
 			cm, err = crypt.NewEtcdConfigManager([]string{rp.Endpoint()}, kr)
 		} else {


### PR DESCRIPTION
A `:=` assignment inside an if-block caused two `error` variables to be shadowed. Here is a fix.