### PR TITLE
Revert unmarshal keys containing dots

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1789,24 +1789,6 @@ outer:
 	return shadow
 }
 
-// Converts a fully qualified map key into a list of relative
-// map keys, allowing for keys to contain the delimiter themselves
-func keyComponents(v *Viper, key string) []string {
-	var result []string
-	components := strings.Split(key, v.keyDelim)
-	for index := 0; index < len(components); index++ {
-		potentialKey := strings.Join(components[0:index], v.keyDelim)
-		if v.Get(potentialKey) != nil {
-			result = append(result, potentialKey)
-		}
-	}
-	result = append(result, key)
-	for i := len(result) - 1; i > 0; i-- {
-		result[i] = strings.Replace(result[i], result[i-1]+v.keyDelim, "", 1)
-	}
-	return result
-}
-
 // AllSettings merges all settings and returns them as a map[string]interface{}.
 func AllSettings() map[string]interface{} { return v.AllSettings() }
 func (v *Viper) AllSettings() map[string]interface{} {
@@ -1819,7 +1801,7 @@ func (v *Viper) AllSettings() map[string]interface{} {
 			// check just in case anything changes
 			continue
 		}
-		path := keyComponents(v, k)
+		path := strings.Split(k, v.keyDelim)
 		lastKey := strings.ToLower(path[len(path)-1])
 		deepestMap := deepSearch(m, path[0:len(path)-1])
 		// set innermost value

--- a/viper_test.go
+++ b/viper_test.go
@@ -46,10 +46,6 @@ clothing:
 age: 35
 eyes : brown
 beard: true
-emails:
-  steve@hacker.com:
-    created: 01/02/03
-    active: true
 `)
 
 var yamlExampleWithExtras = []byte(`Existing: true
@@ -535,8 +531,6 @@ func TestAllKeys(t *testing.T) {
 		"title_dotenv",
 		"type_dotenv",
 		"name_dotenv",
-		"emails.steve@hacker.com.active",
-		"emails.steve@hacker.com.created",
 	}
 	dob, _ := time.Parse(time.RFC3339, "1979-05-27T07:32:00Z")
 	all := map[string]interface{}{
@@ -547,13 +541,7 @@ func TestAllKeys(t *testing.T) {
 		},
 		"title": "TOML Example",
 		"ppu":   0.55,
-		"emails": map[string]interface{}{
-			"steve@hacker.com": map[string]interface{}{
-				"active":  true,
-				"created": "01/02/03",
-			},
-		},
-		"eyes": "brown",
+		"eyes":  "brown",
 		"clothing": map[string]interface{}{
 			"trousers": "denim",
 			"jacket":   "leather",
@@ -1316,10 +1304,6 @@ clothing:
   pants:
     size: large
   trousers: denim
-emails:
-  steve@hacker.com:
-    active: true
-    created: 01/02/03
 eyes: brown
 hacker: true
 hobbies:

--- a/viper_test.go
+++ b/viper_test.go
@@ -254,7 +254,7 @@ func initDirs(t *testing.T) (string, string, func()) {
 	}
 }
 
-//stubs for PFlag Values
+// stubs for PFlag Values
 type stringValue string
 
 func newStringValue(val string, p *string) *stringValue {
@@ -864,7 +864,7 @@ func TestBindPFlag(t *testing.T) {
 	assert.Equal(t, testString, Get("testvalue"))
 
 	flag.Value.Set("testing_mutate")
-	flag.Changed = true //hack for pflag usage
+	flag.Changed = true // hack for pflag usage
 
 	assert.Equal(t, "testing_mutate", Get("testvalue"))
 
@@ -1854,6 +1854,23 @@ func TestWatchFile(t *testing.T) {
 		assert.Equal(t, "baz", v.Get("foo"))
 	})
 
+}
+
+func TestUnmarshal_DotSeparatorBackwardCompatibility(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.String("foo.bar", "cobra_flag", "")
+
+	v := New()
+	assert.NoError(t, v.BindPFlags(flags))
+
+	config := &struct {
+		Foo struct {
+			Bar string
+		}
+	}{}
+
+	assert.NoError(t, v.Unmarshal(config))
+	assert.Equal(t, "cobra_flag", config.Foo.Bar)
 }
 
 func BenchmarkGetBool(b *testing.B) {


### PR DESCRIPTION
This PR reverts #673 because it introduced a breaking change.

Fixes #764