### PR TITLE
Adding support for Terraform files

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -231,7 +231,7 @@ func New() *Viper {
 // can use it in their testing as well.
 func Reset() {
 	v = New()
-	SupportedExts = []string{"json", "toml", "yaml", "yml", "properties", "props", "prop", "hcl", "dotenv", "env"}
+	SupportedExts = []string{"json", "toml", "yaml", "yml", "properties", "props", "prop", "hcl", "tf", "dotenv", "env"}
 	SupportedRemoteProviders = []string{"etcd", "consul"}
 }
 
@@ -270,7 +270,7 @@ type RemoteProvider interface {
 }
 
 // SupportedExts are universally supported extensions.
-var SupportedExts = []string{"json", "toml", "yaml", "yml", "properties", "props", "prop", "hcl", "dotenv", "env"}
+var SupportedExts = []string{"json", "toml", "yaml", "yml", "properties", "props", "prop", "hcl", "tf", "dotenv", "env"}
 
 // SupportedRemoteProviders are universally supported remote providers.
 var SupportedRemoteProviders = []string{"etcd", "consul"}


### PR DESCRIPTION
Would like to add support for Terraform (.tf) files.  Terraform is a HashiCorp product and is written in the HCL syntax, albeit with a different extension.

Documentation to verify Terraform uses HCL syntax in current version: https://www.terraform.io/docs/configuration/syntax.html

Documentation to verify Terraform uses HCL syntax in older versions: https://www.terraform.io/docs/configuration-0-11/syntax.html

I'm totally willing to admit upfront that Terraform isn't an intended format for configuration files for an application, but rather a utility that allows you to write infrastructure as code for a huge number of different providers such as AWS, Azure, GCP, etc. The ability to natively read these file formats out of a package like Viper would be amazingly helpful.