### PR TITLE
Add key delimiter setter

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,8 +665,7 @@ If you want to unmarshal configuration where the keys themselves contain dot (th
 you have to change the delimiter:
 
 ```go
-v := viper.New()
-v.SetKeyDelimiter("::")
+v := viper.NewWithOptions(viper.KeyDelimiter("::"))
 
 v.SetDefault("chart::values", map[string]interface{}{
     "ingress": map[string]interface{}{

--- a/README.md
+++ b/README.md
@@ -661,6 +661,33 @@ if err != nil {
 }
 ```
 
+If you want to unmarshal configuration where the keys themselves contain dot (the default key delimiter),
+you have to change the delimiter:
+
+```go
+v := viper.New()
+v.SetKeyDelimiter("::")
+
+v.SetDefault("chart::values", map[string]interface{}{
+    "ingress": map[string]interface{}{
+        "annotations": map[string]interface{}{
+            "traefik.frontend.rule.type":                 "PathPrefix",
+            "traefik.ingress.kubernetes.io/ssl-redirect": "true",
+        },
+    },
+})
+
+type config struct {
+	Chart struct{
+        Values map[string]interface{}
+    }
+}
+
+var C config
+
+viper.Unmarshal(&C)
+```
+
 Viper uses [github.com/mitchellh/mapstructure](https://github.com/mitchellh/mapstructure) under the hood for unmarshaling values which uses `mapstructure` tags by default.
 
 ### Marshalling to string

--- a/README.md
+++ b/README.md
@@ -684,7 +684,7 @@ type config struct {
 
 var C config
 
-viper.Unmarshal(&C)
+v.Unmarshal(&C)
 ```
 
 Viper uses [github.com/mitchellh/mapstructure](https://github.com/mitchellh/mapstructure) under the hood for unmarshaling values which uses `mapstructure` tags by default.

--- a/viper.go
+++ b/viper.go
@@ -34,14 +34,14 @@ import (
 	"sync"
 	"time"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/printer"
 	"github.com/magiconair/properties"
 	"github.com/mitchellh/mapstructure"
-	toml "github.com/pelletier/go-toml"
+	"github.com/pelletier/go-toml"
 	"github.com/spf13/afero"
 	"github.com/spf13/cast"
 	jww "github.com/spf13/jwalterweatherman"
@@ -243,6 +243,15 @@ func Reset() {
 	v = New()
 	SupportedExts = []string{"json", "toml", "yaml", "yml", "properties", "props", "prop", "hcl", "dotenv", "env", "ini"}
 	SupportedRemoteProviders = []string{"etcd", "consul"}
+}
+
+// SetKeyDelimiter sets the delimiter used for determining key parts.
+// By default it's value is ".".
+func SetKeyDelimiter(keyDelim string) { v.SetKeyDelimiter(keyDelim) }
+func (v *Viper) SetKeyDelimiter(keyDelim string) {
+	if keyDelim != "" {
+		v.keyDelim = keyDelim
+	}
 }
 
 type defaultRemoteProvider struct {
@@ -1720,7 +1729,7 @@ func (v *Viper) getRemoteConfig(provider RemoteProvider) (map[string]interface{}
 func (v *Viper) watchKeyValueConfigOnChannel() error {
 	for _, rp := range v.remoteProviders {
 		respc, _ := RemoteConfig.WatchChannel(rp)
-		//Todo: Add quit channel
+		// Todo: Add quit channel
 		go func(rc <-chan *RemoteResponse) {
 			for {
 				b := <-rc
@@ -1756,7 +1765,7 @@ func (v *Viper) watchRemoteConfig(provider RemoteProvider) (map[string]interface
 }
 
 // AllKeys returns all keys holding a value, regardless of where they are set.
-// Nested keys are returned with a v.keyDelim (= ".") separator
+// Nested keys are returned with a v.keyDelim separator
 func AllKeys() []string { return v.AllKeys() }
 func (v *Viper) AllKeys() []string {
 	m := map[string]bool{}
@@ -1779,7 +1788,7 @@ func (v *Viper) AllKeys() []string {
 
 // flattenAndMergeMap recursively flattens the given map into a map[string]bool
 // of key paths (used as a set, easier to manipulate than a []string):
-// - each path is merged into a single key string, delimited with v.keyDelim (= ".")
+// - each path is merged into a single key string, delimited with v.keyDelim
 // - if a path is shadowed by an earlier value in the initial shadow map,
 //   it is skipped.
 // The resulting set of paths is merged to the given shadow set at the same time.

--- a/viper.go
+++ b/viper.go
@@ -236,6 +236,39 @@ func New() *Viper {
 	return v
 }
 
+// Option configures Viper using the functional options paradigm popularized by Rob Pike and Dave Cheney.
+// If you're unfamiliar with this style,
+// see https://commandcenter.blogspot.com/2014/01/self-referential-functions-and-design.html and
+// https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis.
+type Option interface {
+	apply(v *Viper)
+}
+
+type optionFunc func(v *Viper)
+
+func (fn optionFunc) apply(v *Viper) {
+	fn(v)
+}
+
+// KeyDelimiter sets the delimiter used for determining key parts.
+// By default it's value is ".".
+func KeyDelimiter(d string) Option {
+	return optionFunc(func(v *Viper) {
+		v.keyDelim = d
+	})
+}
+
+// NewWithOptions creates a new Viper instance.
+func NewWithOptions(opts ...Option) *Viper {
+	v := New()
+
+	for _, opt := range opts {
+		opt.apply(v)
+	}
+
+	return v
+}
+
 // Reset is intended for testing, will reset all to default settings.
 // In the public interface for the viper package so applications
 // can use it in their testing as well.
@@ -243,15 +276,6 @@ func Reset() {
 	v = New()
 	SupportedExts = []string{"json", "toml", "yaml", "yml", "properties", "props", "prop", "hcl", "dotenv", "env", "ini"}
 	SupportedRemoteProviders = []string{"etcd", "consul"}
-}
-
-// SetKeyDelimiter sets the delimiter used for determining key parts.
-// By default it's value is ".".
-func SetKeyDelimiter(keyDelim string) { v.SetKeyDelimiter(keyDelim) }
-func (v *Viper) SetKeyDelimiter(keyDelim string) {
-	if keyDelim != "" {
-		v.keyDelim = keyDelim
-	}
 }
 
 type defaultRemoteProvider struct {

--- a/viper.go
+++ b/viper.go
@@ -34,8 +34,6 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/yaml.v2"
-
 	"github.com/fsnotify/fsnotify"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/printer"
@@ -48,6 +46,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/subosito/gotenv"
 	"gopkg.in/ini.v1"
+	"gopkg.in/yaml.v2"
 )
 
 // ConfigMarshalError happens when failing to marshal the configuration.

--- a/viper_test.go
+++ b/viper_test.go
@@ -2029,9 +2029,8 @@ emails:
     active: true
 `)
 
-func TestSetKeyDelimiter(t *testing.T) {
-	v := New()
-	v.SetKeyDelimiter("::")
+func TestKeyDelimiter(t *testing.T) {
+	v := NewWithOptions(KeyDelimiter("::"))
 	v.SetConfigType("yaml")
 	r := strings.NewReader(string(yamlExampleWithDot))
 


### PR DESCRIPTION
This PR adds a new constructor for Viper and a functional option for the key delimiter. This is an initial solution for supporting keys containing the key delimiter.

For the mid-term, I would probably add back the feature reverted in #771 (and fixed in #766) with a feature flag `v.AllowDelimiterInKey` defaulting to false. That changes the behavior of Viper though (see https://github.com/spf13/viper/pull/766#issuecomment-532644550) which is why we need the flag, defaulting to false.

cc @inkychris @mschneider82