### PR TITLE
Verified flag != nil in viper.BindPFlag

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -981,7 +981,7 @@ func (v *Viper) BindPFlags(flags *pflag.FlagSet) error {
 func BindPFlag(key string, flag *pflag.Flag) error { return v.BindPFlag(key, flag) }
 func (v *Viper) BindPFlag(key string, flag *pflag.Flag) error {
 	if flag == nil {
-		return fmt.Errorf("flag for %q is nil", flag)
+		return fmt.Errorf("flag given for %q is nil", key)
 	}
 	return v.BindFlagValue(key, pflagValue{flag})
 }

--- a/viper.go
+++ b/viper.go
@@ -980,6 +980,9 @@ func (v *Viper) BindPFlags(flags *pflag.FlagSet) error {
 //
 func BindPFlag(key string, flag *pflag.Flag) error { return v.BindPFlag(key, flag) }
 func (v *Viper) BindPFlag(key string, flag *pflag.Flag) error {
+	if flag == nil {
+		return fmt.Errorf("flag for %q is nil", flag)
+	}
 	return v.BindFlagValue(key, pflagValue{flag})
 }
 


### PR DESCRIPTION
viper.BindPFlag(key, nil) dosen't return error

## Example Code:
```golang
func main() {
    viper.SetConfigName("config") // name of config file (without extension)
    viper.SetConfigType("toml")
    viper.AddConfigPath(".") // Checks in current directory, Only for debugging purpose
    err := viper.ReadInConfig()
    if err != nil { // Handle errors reading the config file
        panic(err)
    }

    // flag creation
    pflag.String("name", "UserName", "username")
    pflag.Parse()

    // sent "nam" instead of "name" to get nil in return
    err = viper.BindPFlag("name", pflag.Lookup("nam")) // pflag.Lookup("nam") = nil
    // viper assinged nil to "name" because it didn't check for nil
    if err != nil { // err = nil
        panic(err)
    }
  
    fmt.Printf("name = %v\n", viper.Get("name")) // panics because it previouly assinged nil to "name"
}
```
## Solution:
Added a check to verify a given flag is not nil in BindPFlag, it is checked in BindFlagValue but because of the `pflagValue{flag}` it is not being caught
