### PR TITLE
Use ristretto to improve find performance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,12 @@ require (
 	github.com/coreos/bbolt v1.3.2 // indirect
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
+	github.com/dgraph-io/ristretto v0.0.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/gogo/protobuf v1.2.1 // indirect
-	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.3.3 // indirect
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,7 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -33,6 +34,7 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c h1:+0HFd5KSZ/mm3JmhmrDukiId5iR6w4+BdFtfSy4yWIc=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2 h1:wZwiHHUieZCquLkDL0B8UhzreNWsPHooDAG3q34zk0s=
@@ -48,8 +50,12 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgraph-io/ristretto v0.0.1 h1:cJwdnj42uV8Jg4+KLrYovLiCgIfz9wtWm6E6KA+1tLs=
+github.com/dgraph-io/ristretto v0.0.1/go.mod h1:T40EBc7CJke8TkpiYfGGKAeFjSaxuFXhuXRyumBd6RE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
+github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
@@ -66,8 +72,8 @@ github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef h1:veQD95Isof8w9/WXiA+pa3tz3fJXkt5B7QaRBrM62gk=
-github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
+github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
@@ -76,6 +82,8 @@ github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
+github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -214,6 +222,7 @@ github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIK
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4 h1:0HKaf1o97UwFjHH9o5XsHUOF+tqmdA7KEzXLpiyaw0E=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
+github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/stub/benchmark.json
+++ b/stub/benchmark.json
@@ -1,0 +1,248 @@
+{
+    "log": {
+        "level": "debug",
+        "format": "json"
+    },
+    "profiling": "cpu",
+    "serve": {
+        "proxy": {
+            "port": 1234,
+            "host": "127.0.0.1",
+            "timeout": {
+                "read": "1s",
+                "write": "2s",
+                "idle": "3s"
+            },
+            "cors": {
+                "enabled": true,
+                "allowed_origins": [
+                    "https://example.com",
+                    "https://*.example.com"
+                ],
+                "allowed_methods": [
+                    "POST",
+                    "GET",
+                    "PUT",
+                    "PATCH",
+                    "DELETE"
+                ],
+                "allowed_headers": [
+                    "Authorization",
+                    "Content-Type"
+                ],
+                "exposed_headers": [
+                    "Content-Type"
+                ],
+                "allow_credentials": true,
+                "max_age": 10,
+                "debug": true
+            },
+            "tls": {
+                "key": {
+                    "path": "/path/to/key.pem",
+                    "base64": "LS0tLS1CRUdJTiBFTkNSWVBURUQgUFJJVkFURSBLRVktLS0tLVxuTUlJRkRqQkFCZ2txaGtpRzl3MEJCUTB3..."
+                },
+                "cert": {
+                    "path": "/path/to/cert.pem",
+                    "base64": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlEWlRDQ0FrMmdBd0lCQWdJRVY1eE90REFOQmdr..."
+                }
+            }
+        },
+        "api": {
+            "port": 1235,
+            "host": "127.0.0.2",
+            "cors": {
+                "enabled": true,
+                "allowed_origins": [
+                    "https://example.org",
+                    "https://*.example.org"
+                ],
+                "allowed_methods": [
+                    "GET",
+                    "PUT",
+                    "PATCH",
+                    "DELETE"
+                ],
+                "allowed_headers": [
+                    "Authorization",
+                    "Content-Type"
+                ],
+                "exposed_headers": [
+                    "Content-Type"
+                ],
+                "allow_credentials": true,
+                "max_age": 10,
+                "debug": true
+            },
+            "tls": {
+                "key": {
+                    "path": "/path/to/key.pem",
+                    "base64": "LS0tLS1CRUdJTiBFTkNSWVBURUQgUFJJVkFURSBLRVktLS0tLVxuTUlJRkRqQkFCZ2txaGtpRzl3MEJCUTB3..."
+                },
+                "cert": {
+                    "path": "/path/to/cert.pem",
+                    "base64": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlEWlRDQ0FrMmdBd0lCQWdJRVY1eE90REFOQmdr..."
+                }
+            }
+        }
+    },
+    "access_rules": {
+        "repositories": [
+            "file://path/to/rules.json",
+            "inline://W3siaWQiOiJmb28tcnVsZSIsImF1dGhlbnRpY2F0b3JzIjpbXX1d",
+            "https://path-to-my-rules/rules.json"
+        ],
+        "matching_strategy": "glob"
+    },
+    "errors": {
+        "fallback": [
+            "json"
+        ],
+        "handlers": {
+            "redirect": {
+                "enabled": true,
+                "config": {
+                    "to": "http://path-to/redirect"
+                }
+            },
+            "json": {
+                "enabled": true,
+                "config": {
+                    "verbose": true,
+                    "when": [
+                    {
+                        "error": [
+                            "unauthorized",
+                            "forbidden",
+                            "internal_server_error"
+                        ],
+                        "request": {
+                            "header": {
+                                "content_type": [
+                                    "application/json"
+                                ],
+                                "accept": [
+                                    "application/json"
+                                ]
+                            },
+                            "cidr": [
+                                "127.0.0.0/24"
+                            ]
+                        }
+                    }
+                    ]
+                }
+            }
+        }
+    },
+    "authenticators": {
+        "anonymous": {
+            "enabled": true,
+            "config": {
+                "subject": "guest"
+            }
+        },
+        "cookie_session": {
+            "enabled": true,
+            "config": {
+                "check_session_url": "https://session-store-host",
+                "only": [
+                    "sessionid"
+                ]
+            }
+        },
+        "jwt": {
+            "enabled": true,
+            "config": {
+                "jwks_urls": [
+                    "https://my-website.com/.well-known/jwks.json",
+                    "https://my-other-website.com/.well-known/jwks.json",
+                    "file://path/to/local/jwks.json"
+                ],
+                "scope_strategy": "wildcard"
+            }
+        },
+        "noop": {
+            "enabled": true
+        },
+        "oauth2_client_credentials": {
+            "enabled": true,
+            "config": {
+                "token_url": "https://my-website.com/oauth2/token"
+            }
+        },
+        "oauth2_introspection": {
+            "enabled": true,
+            "config": {
+                "introspection_url": "https://my-website.com/oauth2/introspection",
+                "scope_strategy": "exact",
+                "pre_authorization": {
+                    "enabled": true,
+                    "client_id": "some_id",
+                    "client_secret": "some_secret",
+                    "scope": [
+                        "foo",
+                        "bar"
+                    ],
+                    "token_url": "https://my-website.com/oauth2/token"
+                }
+            }
+        },
+        "unauthorized": {
+            "enabled": true
+        }
+    },
+    "authorizers": {
+        "allow": {
+            "enabled": true
+        },
+        "deny": {
+            "enabled": true
+        },
+        "keto_engine_acp_ory": {
+            "enabled": true,
+            "config": {
+                "base_url": "http://my-keto/",
+                "required_action": "unknown",
+                "required_resource": "unknown"
+            }
+        }
+    },
+    "mutators": {
+        "header": {
+            "enabled": false,
+            "config": {
+                "headers": {
+                    "foo": "bar"
+                }
+            }
+        },
+        "cookie": {
+            "enabled": true,
+            "config": {
+                "cookies": {
+                    "foo": "bar"
+                }
+            }
+        },
+        "hydrator": {
+            "enabled": true,
+            "config": {
+                "api": {
+                    "url": "https://some-url/"
+                }
+            }
+        },
+        "id_token": {
+            "enabled": true,
+            "config": {
+                "issuer_url": "https://my-oathkeeper/",
+                "jwks_url": "https://fetch-keys/from/this/location.json",
+                "ttl": "1h"
+            }
+        },
+        "noop": {
+            "enabled": true
+        }
+    }
+}


### PR DESCRIPTION
As discussed in another PR, `v.find` performance deteriorates as the config map grows and more config sources come in. We can significantly improve the performance of `v.find` operations (and thus all `Get*` operations) with a simple cache strategy.

As you can see in the benchmark below, not using a cache needs 4060 ns/op for reading all keys of a large config file, while using a cache reduces that time to 171ns/op on average.

Ristretto was chosen because it is a very performant, thread-safe
cache that does not suffer form congestion or long GC pauses.

```
% go test -bench=. .
goos: darwin
goarch: amd64
pkg: github.com/spf13/viper
BenchmarkFind/cache=false-8       289495              4060 ns/op
BenchmarkFind/cache=true-8       6980976               171 ns/op
PASS
```