### PR TITLE
Added support for accessing slices

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,33 @@ the `Set()` method, …) with an immediate value, then all sub-keys of
 `datastore.metric` become undefined, they are “shadowed” by the higher-priority
 configuration level.
 
+Viper can access array indices by using numbers in the path. For example:
+
+```json
+{
+    "host": {
+        "address": "localhost",
+        "ports": [
+            5799,
+            6029
+        ]
+    },
+    "datastore": {
+        "metric": {
+            "host": "127.0.0.1",
+            "port": 3099
+        },
+        "warehouse": {
+            "host": "198.0.0.1",
+            "port": 2112
+        }
+    }
+}
+
+GetInt("host.ports.1") // returns 6029
+
+```
+
 Lastly, if there exists a key that matches the delimited key path, its value
 will be returned instead. E.g.
 

--- a/viper.go
+++ b/viper.go
@@ -602,9 +602,7 @@ func (v *Viper) searchMapWithPathPrefixes(source interface{}, path []string) int
 	// search for path prefixes, starting from the longest one
 	for i := len(path); i > 0; i-- {
 		prefixKey := strings.ToLower(strings.Join(path[0:i], v.keyDelim))
-
 		if sourceSlice, ok := source.([]interface{}); ok {
-
 			//if the prefixKey is a number which is not out of bounds of the slice
 			if index, err := strconv.Atoi(prefixKey); err == nil && len(sourceSlice) > index {
 				next := sourceSlice[index]

--- a/viper.go
+++ b/viper.go
@@ -642,17 +642,13 @@ func (v *Viper) searchSliceWithPathPrefixes(
 		return next
 	}
 
-	var val interface{}
 	switch n := next.(type) {
 	case map[interface{}]interface{}:
-		val = v.searchIndexableWithPathPrefixes(cast.ToStringMap(n), path[pathIndex:])
+		return v.searchIndexableWithPathPrefixes(cast.ToStringMap(n), path[pathIndex:])
 	case map[string]interface{}, []interface{}:
-		val = v.searchIndexableWithPathPrefixes(n, path[pathIndex:])
+		return v.searchIndexableWithPathPrefixes(n, path[pathIndex:])
 	default:
 		// got a value but nested key expected, do nothing and look for next prefix
-	}
-	if val != nil {
-		return val
 	}
 
 	// not found
@@ -680,17 +676,13 @@ func (v *Viper) searchMapWithPathPrefixes(
 	}
 
 	// Nested case
-	var val interface{}
 	switch n := next.(type) {
 	case map[interface{}]interface{}:
-		val = v.searchIndexableWithPathPrefixes(cast.ToStringMap(n), path[pathIndex:])
+		return v.searchIndexableWithPathPrefixes(cast.ToStringMap(n), path[pathIndex:])
 	case map[string]interface{}, []interface{}:
-		val = v.searchIndexableWithPathPrefixes(n, path[pathIndex:])
+		return v.searchIndexableWithPathPrefixes(n, path[pathIndex:])
 	default:
 		// got a value but nested key expected, do nothing and look for next prefix
-	}
-	if val != nil {
-		return val
 	}
 
 	// not found

--- a/viper_test.go
+++ b/viper_test.go
@@ -2315,7 +2315,7 @@ func TestSliceIndexAccess(t *testing.T) {
 	assert.Equal(t, "Static", v.GetString("tv.0.seasons.1.episodes.2.title"))
 	assert.Equal(t, "December 15, 2015", v.GetString("tv.0.seasons.0.episodes.1.air_date"))
 
-	//Test for index out of bounds
+	// Test for index out of bounds
 	assert.Equal(t, "", v.GetString("tv.0.seasons.2.first_released"))
 
 	// Accessing multidimensional arrays

--- a/viper_test.go
+++ b/viper_test.go
@@ -2279,6 +2279,49 @@ func TestKeyDelimiter(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+var yamlDeepNestedSlices = []byte(`TV:
+- title: "The expanse"
+  seasons:
+  - first_released: "December 14, 2015"
+    episodes:
+    - title: "Dulcinea"
+      air_date: "December 14, 2015"
+    - title: "The Big Empty"
+      air_date: "December 15, 2015"
+    - title: "Remember the Cant"
+      air_date: "December 22, 2015"
+  - first_released: "February 1, 2017"
+    episodes:
+    - title: "Safe"
+      air_date: "February 1, 2017"
+    - title: "Doors & Corners"
+      air_date: "February 1, 2017"
+    - title: "Static"
+      air_date: "February 8, 2017"
+  episodes:
+    - ["Dulcinea", "The Big Empty", "Remember the Cant"]
+    - ["Safe", "Doors & Corners", "Static"]
+`)
+
+func TestSliceIndexAccess(t *testing.T) {
+	v.SetConfigType("yaml")
+	r := strings.NewReader(string(yamlDeepNestedSlices))
+
+	err := v.unmarshalReader(r, v.config)
+	require.NoError(t, err)
+
+	assert.Equal(t, "The expanse", v.GetString("tv.0.title"))
+	assert.Equal(t, "February 1, 2017", v.GetString("tv.0.seasons.1.first_released"))
+	assert.Equal(t, "Static", v.GetString("tv.0.seasons.1.episodes.2.title"))
+	assert.Equal(t, "December 15, 2015", v.GetString("tv.0.seasons.0.episodes.1.air_date"))
+
+	//Test for index out of bounds
+	assert.Equal(t, "", v.GetString("tv.0.seasons.2.first_released"))
+
+	// Accessing multidimensional arrays
+	assert.Equal(t, "Static", v.GetString("tv.0.episodes.1.2"))
+}
+
 func BenchmarkGetBool(b *testing.B) {
 	key := "BenchmarkGetBool"
 	v = New()


### PR DESCRIPTION
Hi,
I added support for accessing values within a slice as mentioned in #196. For example, if we have a config file which is structured like this:
```json
{
  "server_name": "example.com",
  "interfaces": [
    {
        "interface": "192.168.1.1",
        "port": 80
    },
    {
        "interface": "127.0.0.1",
        "port": 8080
    }
  ]
}
```

We can now get the second interface config like so `viper.Get("interfaces.1")` or specifically the port like so `viper.GetInt("interfaces.1.port")`

I have chosen to implement the index numbers like path parts since it is way more difficult to try to parse the go like syntax `viper.Get("interfaces[1]")` and still respect the other functionality like shadowing checks.