### PR TITLE
Fix panic while writing invalid ini

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1620,8 +1620,8 @@ func (v *Viper) marshalWriter(f afero.File, configType string) error {
 				err := fmt.Errorf("missing key for %s", key)
 				return ConfigMarshalError{err}
 			}
-			sectionName := key[:(lastSep)]
-			keyName := key[(lastSep + 1):]
+			sectionName := key[:lastSep]
+			keyName := key[lastSep+1:]
 			if sectionName == "default" {
 				sectionName = ""
 			}

--- a/viper.go
+++ b/viper.go
@@ -1616,6 +1616,10 @@ func (v *Viper) marshalWriter(f afero.File, configType string) error {
 		for i := 0; i < len(keys); i++ {
 			key := keys[i]
 			lastSep := strings.LastIndex(key, ".")
+			if lastSep < 0 {
+				err := fmt.Errorf("missing key for %s", key)
+				return ConfigMarshalError{err}
+			}
 			sectionName := key[:(lastSep)]
 			keyName := key[(lastSep + 1):]
 			if sectionName == "default" {

--- a/viper_test.go
+++ b/viper_test.go
@@ -1558,6 +1558,22 @@ func TestWriteConfigDotEnv(t *testing.T) {
 	}
 }
 
+func TestWriteConfigInvalidIni(t *testing.T) {
+	v := New()
+	fs := afero.NewMemMapFs()
+	v.SetFs(fs)
+	v.SetConfigName("c")
+	v.SetConfigType("ini")
+	v.Set("x", "y")
+	err := v.WriteConfigAs("c.ini")
+	require.NotNil(t, err, "invalid ini is expected to return an error")
+	_, ok := err.(ConfigMarshalError)
+	if !ok {
+		t.Fatalf("ConfigMarshalError type is expected, but got %T type",
+			err)
+	}
+}
+
 func TestSafeWriteConfig(t *testing.T) {
 	v := New()
 	fs := afero.NewMemMapFs()


### PR DESCRIPTION
Each item of .ini consists of section and key. If section is present and key is missing, writing in ini format should return an error. But it panics now.

```go
// This is an error when written in ini format.
viper.Set("only_section", "anything")
```
