### PR TITLE
Make Viper.Sub() inherit values from the bound pflags of the parent

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -780,11 +780,21 @@ func (v *Viper) Sub(key string) *Viper {
 		return nil
 	}
 
-	if reflect.TypeOf(data).Kind() == reflect.Map {
-		subv.config = cast.ToStringMap(data)
-		return subv
+	if !(reflect.TypeOf(data).Kind() == reflect.Map) {
+		return nil
 	}
-	return nil
+	subv.config = cast.ToStringMap(data)
+	subPFlags := make(map[string]FlagValue)
+	for flagName, flagValue := range v.pflags {
+		keyPrefix := key + "."
+		if !strings.HasPrefix(flagName, keyPrefix) {
+			continue
+		}
+		newFlagName := flagName[len(keyPrefix):]
+		subPFlags[newFlagName] = flagValue
+	}
+	subv.pflags = subPFlags
+	return subv
 }
 
 // GetString returns the value associated with the key as a string.


### PR DESCRIPTION
Sub creates a new instance from a sub-tree, but bound flags
are not passed down to the new instance. This commit adds
the bound flags that are prefixed as the provided k to the
new instance.