### PR TITLE
fix bug while saving ini file

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1621,7 +1621,7 @@ func (v *Viper) marshalWriter(f afero.File, configType string) error {
 			if sectionName == "default" {
 				sectionName = ""
 			}
-			cfg.Section(sectionName).Key(keyName).SetValue(Get(key).(string))
+			cfg.Section(sectionName).Key(keyName).SetValue(v.Get(key).(string))
 		}
 		cfg.WriteTo(f)
 	}


### PR DESCRIPTION
While new Viper with ini file and call method v.WriteConfig or v.WriteConfigAs, the method will return err "interface conversion: interface {} is nil, not string"



