### PR TITLE
Fix: Getting the value of a StringToString pflag

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1083,6 +1083,16 @@ func (v *Viper) find(lcaseKey string, flagDefault bool) interface{} {
 			s = strings.TrimSuffix(s, "]")
 			res, _ := readAsCSV(s)
 			return cast.ToIntSlice(res)
+		case "stringToString":
+			s := strings.TrimPrefix(flag.ValueString(), "[")
+			s = strings.TrimSuffix(s, "]")
+			elements := strings.Split(s, ",")
+			result := make(map[string]string, len(elements))
+			for _, element := range elements {
+				pair := strings.SplitN(element, "=", 2)
+				result[pair[0]] = pair[1]
+			}
+			return result
 		default:
 			return flag.ValueString()
 		}

--- a/viper.go
+++ b/viper.go
@@ -1086,6 +1086,9 @@ func (v *Viper) find(lcaseKey string, flagDefault bool) interface{} {
 		case "stringToString":
 			s := strings.TrimPrefix(flag.ValueString(), "[")
 			s = strings.TrimSuffix(s, "]")
+			if s == "" {
+				return nil
+			}
 			elements := strings.Split(s, ",")
 			result := make(map[string]string, len(elements))
 			for _, element := range elements {
@@ -1168,6 +1171,19 @@ func (v *Viper) find(lcaseKey string, flagDefault bool) interface{} {
 				s = strings.TrimSuffix(s, "]")
 				res, _ := readAsCSV(s)
 				return cast.ToIntSlice(res)
+			case "stringToString":
+				s := strings.TrimPrefix(flag.ValueString(), "[")
+				s = strings.TrimSuffix(s, "]")
+				if s == "" {
+					return nil
+				}
+				elements := strings.Split(s, ",")
+				result := make(map[string]string, len(elements))
+				for _, element := range elements {
+					pair := strings.SplitN(element, "=", 2)
+					result[pair[0]] = pair[1]
+				}
+				return result
 			default:
 				return flag.ValueString()
 			}

--- a/viper.go
+++ b/viper.go
@@ -1191,6 +1191,9 @@ func parseStringToStringFlagValue(val string) map[string]string {
 	result := make(map[string]string, len(elements))
 	for _, element := range elements {
 		pair := strings.SplitN(element, "=", 2)
+		if len(pair) != 2 {
+			return nil
+		}
 		result[pair[0]] = pair[1]
 	}
 	return result

--- a/viper.go
+++ b/viper.go
@@ -1181,14 +1181,14 @@ func readAsCSV(val string) ([]string, error) {
 	return csvReader.Read()
 }
 
-func parseStringToStringFlagValue(val string) map[string]string {
+func parseStringToStringFlagValue(val string) map[string]interface{} {
 	s := strings.TrimPrefix(val, "[")
 	s = strings.TrimSuffix(s, "]")
 	if s == "" {
 		return nil
 	}
 	elements := strings.Split(s, ",")
-	result := make(map[string]string, len(elements))
+	result := make(map[string]interface{}, len(elements))
 	for _, element := range elements {
 		pair := strings.SplitN(element, "=", 2)
 		if len(pair) != 2 {

--- a/viper.go
+++ b/viper.go
@@ -1084,18 +1084,7 @@ func (v *Viper) find(lcaseKey string, flagDefault bool) interface{} {
 			res, _ := readAsCSV(s)
 			return cast.ToIntSlice(res)
 		case "stringToString":
-			s := strings.TrimPrefix(flag.ValueString(), "[")
-			s = strings.TrimSuffix(s, "]")
-			if s == "" {
-				return nil
-			}
-			elements := strings.Split(s, ",")
-			result := make(map[string]string, len(elements))
-			for _, element := range elements {
-				pair := strings.SplitN(element, "=", 2)
-				result[pair[0]] = pair[1]
-			}
-			return result
+			return parseStringToStringFlagValue(flag.ValueString())
 		default:
 			return flag.ValueString()
 		}
@@ -1172,18 +1161,7 @@ func (v *Viper) find(lcaseKey string, flagDefault bool) interface{} {
 				res, _ := readAsCSV(s)
 				return cast.ToIntSlice(res)
 			case "stringToString":
-				s := strings.TrimPrefix(flag.ValueString(), "[")
-				s = strings.TrimSuffix(s, "]")
-				if s == "" {
-					return nil
-				}
-				elements := strings.Split(s, ",")
-				result := make(map[string]string, len(elements))
-				for _, element := range elements {
-					pair := strings.SplitN(element, "=", 2)
-					result[pair[0]] = pair[1]
-				}
-				return result
+				return parseStringToStringFlagValue(flag.ValueString())
 			default:
 				return flag.ValueString()
 			}
@@ -1201,6 +1179,21 @@ func readAsCSV(val string) ([]string, error) {
 	stringReader := strings.NewReader(val)
 	csvReader := csv.NewReader(stringReader)
 	return csvReader.Read()
+}
+
+func parseStringToStringFlagValue(val string) map[string]string {
+	s := strings.TrimPrefix(val, "[")
+	s = strings.TrimSuffix(s, "]")
+	if s == "" {
+		return nil
+	}
+	elements := strings.Split(s, ",")
+	result := make(map[string]string, len(elements))
+	for _, element := range elements {
+		pair := strings.SplitN(element, "=", 2)
+		result[pair[0]] = pair[1]
+	}
+	return result
 }
 
 // IsSet checks to see if the key has been set in any of the data locations.

--- a/viper_test.go
+++ b/viper_test.go
@@ -978,6 +978,8 @@ func TestBindPFlagStringToString(t *testing.T) {
 		{nil, ""},
 		{map[string]string{"yo": "hi"}, "yo=hi"},
 		{map[string]string{"yo": "hi", "oh": "hi=there"}, "yo=hi,oh=hi=there"},
+		{map[string]string{"yo": ""}, "yo="},
+		{map[string]string{"yo": "", "oh": "hi=there"}, "yo=,oh=hi=there"},
 	}
 
 	v := New() // create independent Viper object

--- a/viper_test.go
+++ b/viper_test.go
@@ -970,6 +970,51 @@ func TestBindPFlag(t *testing.T) {
 	assert.Equal(t, "testing_mutate", Get("testvalue"))
 }
 
+func TestBindPFlagStringToString(t *testing.T) {
+	tests := []struct {
+		Expected map[string]string
+		Value    string
+	}{
+		{nil, ""},
+		{map[string]string{"yo": "hi"}, "yo=hi"},
+		{map[string]string{"yo": "hi", "oh": "hi=there"}, "yo=hi,oh=hi=there"},
+	}
+
+	v := New() // create independent Viper object
+	defaultVal := map[string]string{}
+	v.SetDefault("stringtostring", defaultVal)
+
+	for _, testValue := range tests {
+		flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		flagSet.StringToString("stringtostring", testValue.Expected, "test")
+
+		for _, changed := range []bool{true, false} {
+			flagSet.VisitAll(func(f *pflag.Flag) {
+				f.Value.Set(testValue.Value)
+				f.Changed = changed
+			})
+
+			err := v.BindPFlags(flagSet)
+			if err != nil {
+				t.Fatalf("error binding flag set, %v", err)
+			}
+
+			type TestMap struct {
+				StringToString map[string]string
+			}
+			val := &TestMap{}
+			if err := v.Unmarshal(val); err != nil {
+				t.Fatalf("%+#v cannot unmarshal: %s", testValue.Value, err)
+			}
+			if changed {
+				assert.Equal(t, testValue.Expected, val.StringToString)
+			} else {
+				assert.Equal(t, defaultVal, val.StringToString)
+			}
+		}
+	}
+}
+
 func TestBoundCaseSensitivity(t *testing.T) {
 	assert.Equal(t, "brown", Get("eyes"))
 

--- a/viper_test.go
+++ b/viper_test.go
@@ -975,7 +975,7 @@ func TestBindPFlagStringToString(t *testing.T) {
 		Expected map[string]string
 		Value    string
 	}{
-		{nil, ""},
+		{map[string]string{}, ""},
 		{map[string]string{"yo": "hi"}, "yo=hi"},
 		{map[string]string{"yo": "hi", "oh": "hi=there"}, "yo=hi,oh=hi=there"},
 		{map[string]string{"yo": ""}, "yo="},


### PR DESCRIPTION
As viper parses pflag values as strings, string to string values weren't being handled correctly . Fixes #608 .