### PR TITLE
Add custom metrics for viper.Get calls

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -213,7 +213,8 @@ type Viper struct {
 	// This will only be used if the configuration read is a properties file.
 	properties *properties.Properties
 
-	onConfigChange func(fsnotify.Event)
+	onConfigChange  func(fsnotify.Event)
+	onGetCallMetric func(key string, value interface{})
 }
 
 // New returns an initialized Viper instance.
@@ -537,6 +538,11 @@ func (v *Viper) AddSecureRemoteProvider(provider, endpoint, path, secretkeyring 
 	return nil
 }
 
+func AddGetMetric(getCallMetric func(key string, val interface{})) { v.AddGetMetric(getCallMetric) }
+func (v *Viper) AddGetMetric(getCallMetric func(key string, val interface{})) {
+	v.onGetCallMetric = getCallMetric
+}
+
 func (v *Viper) providerPathExists(p *defaultRemoteProvider) bool {
 	for _, y := range v.remoteProviders {
 		if reflect.DeepEqual(y, p) {
@@ -726,6 +732,9 @@ func Get(key string) interface{} { return v.Get(key) }
 func (v *Viper) Get(key string) interface{} {
 	lcaseKey := strings.ToLower(key)
 	val := v.find(lcaseKey, true)
+	if v.onGetCallMetric != nil {
+		v.onGetCallMetric(key, val)
+	}
 	if val == nil {
 		return nil
 	}


### PR DESCRIPTION
We are using viper at my company and it has been working great! One of the common issues we face is people having a typo in one of their environment variable keys causing them to go down a troubleshooting rabbit hole until it's finally discovered that they didn't override one of their settings. I'd like to have some generic hooks into when a config value is called to allow for custom implementations that can help with troubleshooting. In our case an internal endpoint where we can see the environment variables being called and a list of keys available but not being called.

This pull request would allow people to set up custom metrics for whenever a viper.Get call is made.

Example:
```
        customMetric  := func(key string, val interface{}) {
		fmt.Printf("Config get call made '%v: %+v'\n", key, val)
	}
	v := viper.New()
	v.AddGetMetric(customMetric)

       isPretty := v.GetBool("PRETTY_OUTPUT")
       logLevel := v.GetString("LOG_LEVEL")
       port := v.GetString("server_port")
```

Output:
```
Config get call made 'PRETTY_OUTPUT: <nil>'
Config get call made 'LOG_LEVEL: debug'
Config get call made 'server_port: :8080'
```

Please let me know your thoughts and if you have an idea for a better approach for this problem or recommendation on variable/method names