### PR TITLE
add DebugWith method for specifying where debug output should go (#896)

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -2005,11 +2005,17 @@ func (v *Viper) findConfigFile() (string, error) {
 // purposes.
 func Debug() { v.Debug() }
 func (v *Viper) Debug() {
-	fmt.Printf("Aliases:\n%#v\n", v.aliases)
-	fmt.Printf("Override:\n%#v\n", v.override)
-	fmt.Printf("PFlags:\n%#v\n", v.pflags)
-	fmt.Printf("Env:\n%#v\n", v.env)
-	fmt.Printf("Key/Value Store:\n%#v\n", v.kvstore)
-	fmt.Printf("Config:\n%#v\n", v.config)
-	fmt.Printf("Defaults:\n%#v\n", v.defaults)
+	v.DebugWith(os.Stdout)
+}
+
+// DebugWith prints all configuration registries for debugging to the provided io.Writer.
+func DebugWith(w io.Writer) { v.DebugWith(w) }
+func (v *Viper) DebugWith(w io.Writer) {
+	fmt.Fprintf(w, "Aliases:\n%#v\n", v.aliases)
+	fmt.Fprintf(w, "Override:\n%#v\n", v.override)
+	fmt.Fprintf(w, "PFlags:\n%#v\n", v.pflags)
+	fmt.Fprintf(w, "Env:\n%#v\n", v.env)
+	fmt.Fprintf(w, "Key/Value Store:\n%#v\n", v.kvstore)
+	fmt.Fprintf(w, "Config:\n%#v\n", v.config)
+	fmt.Fprintf(w, "Defaults:\n%#v\n", v.defaults)
 }


### PR DESCRIPTION
This addresses the issue I opened in #896. To avoid breaking changes, I added a DebugWith instead of changing the signature of Debug. It doesn't do any sort of nil check or error handling.