### PR TITLE
fix panic when continue using WatchRemoteConfig

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1775,7 +1775,9 @@ func (v *Viper) watchKeyValueConfigOnChannel() error {
 			for {
 				b := <-rc
 				reader := bytes.NewReader(b.Value)
-				v.unmarshalReader(reader, v.kvstore)
+				kvstore := make(map[string]interface{}, len(v.kvstore))
+				v.unmarshalReader(reader, kvstore)
+				v.kvstore = kvstore
 			}
 		}(respc)
 		return nil
@@ -1801,8 +1803,9 @@ func (v *Viper) watchRemoteConfig(provider RemoteProvider) (map[string]interface
 	if err != nil {
 		return nil, err
 	}
-	err = v.unmarshalReader(reader, v.kvstore)
-	return v.kvstore, err
+	kvstore := make(map[string]interface{}, len(v.kvstore))
+	err = v.unmarshalReader(reader, kvstore)
+	return kvstore, err
 }
 
 // AllKeys returns all keys holding a value, regardless of where they are set.


### PR DESCRIPTION
Hi~
I found a problem when I using Singleton pattern with viper.
I used like Example in readme
```
// open a goroutine to watch remote changes forever
go func(){
	for {
	    time.Sleep(time.Second * 5) // delay after each request

	    // currently, only tested with etcd support
	    err := runtime_viper.WatchRemoteConfig()
	    if err != nil {
	        log.Errorf("unable to read remote config: %v", err)
	        continue
	    }
	}
}()
```
It will be occured panic , meawhile getting to the value.
Hope you like my change