### PR TITLE
support multitype remote config file

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1790,6 +1790,12 @@ func (v *Viper) getRemoteConfig(provider RemoteProvider) (map[string]interface{}
 	if err != nil {
 		return nil, err
 	}
+
+	providerType := strings.Split(provider.Path(), ".")[len(strings.Split(provider.Path(), "."))-1]
+	if v.getConfigType() == "" && stringInSlice(providerType, SupportedExts) {
+		SetConfigType(providerType)
+	}
+
 	err = v.unmarshalReader(reader, v.kvstore)
 	return v.kvstore, err
 }


### PR DESCRIPTION
when remote files in different type, for example .properties and yml, we need two viper instance;
add file type from remote provider path we can get the type of config file, such support different types
