### PR TITLE
Added fuzzer for Get()

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -1,0 +1,6 @@
+package viper
+
+func FuzzGet(data []byte) int {
+	_ = Get(string(data))
+	return 1
+}


### PR DESCRIPTION
To see if there is interest in introducing fuzzing into Viper, I am adding a fuzzer for `Get()`.

One note on this fuzzer: Over time it slows down significantly, and I ask the reviewer to let me know if any utility function needs to free or destroy any created instances. I was not able to find any such functionality myself.

The fuzzer can be run locally, and I can setup coninuous fuzzing as well through oss-fuzz, as I can confirm that the fuzzer does run on their infrastructure.