### PR TITLE
Fix: WriteConfig file extensions check

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1443,11 +1443,10 @@ func (v *Viper) writeConfig(filename string, force bool) error {
 	jww.INFO.Println("Attempting to write configuration to file.")
 	var configType string
 
-	ext := filepath.Ext(filename)
-	if ext != "" {
-		configType = ext[1:]
-	} else {
+	if v.configType != "" {
 		configType = v.configType
+	} else {
+		configType = strings.TrimPrefix(filepath.Ext(filename), ".")
 	}
 	if configType == "" {
 		return fmt.Errorf("config type could not be determined for %s", filename)

--- a/viper_test.go
+++ b/viper_test.go
@@ -1326,7 +1326,7 @@ var hclWriteExpected = []byte(`"foos" = {
 
 "type" = "donut"`)
 
-var hclWriteExpectedFromJsonExample = []byte(`"batters" = {
+var hclWriteExpectedFromJSONExample = []byte(`"batters" = {
   "batter" = {
     "type" = "Regular"
   }
@@ -1499,7 +1499,7 @@ func TestWriteConfig(t *testing.T) {
 			outConfigType:   "hcl",
 			fileName:        "c.json",
 			input:           jsonExample,
-			expectedContent: hclWriteExpectedFromJsonExample,
+			expectedContent: hclWriteExpectedFromJSONExample,
 		},
 		"properties with file extension": {
 			configName:      "c",

--- a/viper_test.go
+++ b/viper_test.go
@@ -1326,6 +1326,32 @@ var hclWriteExpected = []byte(`"foos" = {
 
 "type" = "donut"`)
 
+var hclWriteExpectedFromJsonExample = []byte(`"batters" = {
+  "batter" = {
+    "type" = "Regular"
+  }
+
+  "batter" = {
+    "type" = "Chocolate"
+  }
+
+  "batter" = {
+    "type" = "Blueberry"
+  }
+
+  "batter" = {
+    "type" = "Devil's Food"
+  }
+}
+
+"id" = "0001"
+
+"name" = "Cake"
+
+"ppu" = 0.55
+
+"type" = "donut"`)
+
 var jsonWriteExpected = []byte(`{
   "batters": {
     "batter": [
@@ -1343,6 +1369,31 @@ var jsonWriteExpected = []byte(`{
       }
     ]
   },
+  "id": "0001",
+  "name": "Cake",
+  "ppu": 0.55,
+  "type": "donut"
+}`)
+
+var jsonWriteExpectedFromHclExample = []byte(`{
+  "foos": [
+    {
+      "foo": [
+        {
+          "key": 1
+        },
+        {
+          "key": 2
+        },
+        {
+          "key": 3
+        },
+        {
+          "key": 4
+        }
+      ]
+    }
+  ],
   "id": "0001",
   "name": "Cake",
   "ppu": 0.55,
@@ -1371,6 +1422,26 @@ hobbies:
 - go
 name: steve
 `)
+
+var jsonWriteExpectedFromYamlExample = []byte(`{
+  "age": 35,
+  "beard": true,
+  "clothing": {
+    "jacket": "leather",
+    "pants": {
+      "size": "large"
+    },
+    "trousers": "denim"
+  },
+  "eyes": "brown",
+  "hacker": true,
+  "hobbies": [
+    "skateboarding",
+    "snowboarding",
+    "go"
+  ],
+  "name": "steve"
+}`)
 
 func TestWriteConfig(t *testing.T) {
 	fs := afero.NewMemMapFs()
@@ -1404,7 +1475,7 @@ func TestWriteConfig(t *testing.T) {
 			outConfigType:   "json",
 			fileName:        "c.hcl",
 			input:           hclExample,
-			expectedContent: hclWriteExpected,
+			expectedContent: jsonWriteExpectedFromHclExample,
 		},
 		"json with file extension": {
 			configName:      "c",
@@ -1428,7 +1499,7 @@ func TestWriteConfig(t *testing.T) {
 			outConfigType:   "hcl",
 			fileName:        "c.json",
 			input:           jsonExample,
-			expectedContent: jsonWriteExpected,
+			expectedContent: hclWriteExpectedFromJsonExample,
 		},
 		"properties with file extension": {
 			configName:      "c",
@@ -1468,7 +1539,7 @@ func TestWriteConfig(t *testing.T) {
 			outConfigType:   "json",
 			fileName:        "c.yaml",
 			input:           yamlExample,
-			expectedContent: yamlWriteExpected,
+			expectedContent: jsonWriteExpectedFromYamlExample,
 		},
 	}
 	for name, tc := range testCases {


### PR DESCRIPTION
Fixes #427 .
Closes #428 .

This PR sets the assumption that if the developer ran `SetConfigType` during the loading of a config, they should be able to save the config without concern to the file extension.

The current behavior is that the file extension takes precedence during saving, even when `SetConfigType` was explicitly run.

For example, if the developer loads a `.config` file by setting the config type to TOML, calling `WriteConfig` will fail with `Unsupported Config Type ".config"`, even though the developer explicitly told the framework before that it's a TOML file.

The main impact on current use-cases show well in testing: filenames with the wrong extensions are now written in the format defined in `SetConfigType`, instead of based on the file extension.