### PR TITLE
Rich the ConfigFileNotFoundError to resolve the issue #390

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -113,7 +113,12 @@ type ConfigFileNotFoundError struct {
 
 // Error returns the formatted configuration error.
 func (fnfe ConfigFileNotFoundError) Error() string {
-	return fmt.Sprintf("Config File %q Not Found in %q", fnfe.name, fnfe.locations)
+	configFiles := make([]string, 0, len(SupportedExts))
+	for _, ext := range SupportedExts {
+		configFiles = append(configFiles, fmt.Sprintf("%s.%s", fnfe.name, ext))
+	}
+
+	return fmt.Sprintf("Config Not Found in %q, ConfigFiles:\n %q", fnfe.locations, configFiles)
 }
 
 // ConfigFileAlreadyExistsError denotes failure to write new configuration file.


### PR DESCRIPTION
There is an unfriendly error message for the new users.

The param `in` of function `viper.SetConfigName` always be considered is a full filename.