### PR TITLE
BindPFlag() detect nil flag before wrapping in pflagValue

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -962,6 +962,9 @@ func (v *Viper) BindPFlags(flags *pflag.FlagSet) error {
 //
 func BindPFlag(key string, flag *pflag.Flag) error { return v.BindPFlag(key, flag) }
 func (v *Viper) BindPFlag(key string, flag *pflag.Flag) error {
+	if flag == nil {
+		return fmt.Errorf("flag for %q is nil", key)
+	}
 	return v.BindFlagValue(key, pflagValue{flag})
 }
 

--- a/viper_test.go
+++ b/viper_test.go
@@ -970,6 +970,11 @@ func TestBindPFlag(t *testing.T) {
 	assert.Equal(t, "testing_mutate", Get("testvalue"))
 }
 
+func TestBindPFlagDetectNilFlag(t *testing.T) {
+	result := BindPFlag("testvalue", nil)
+	assert.Error(t, result)
+}
+
 func TestBindPFlagStringToString(t *testing.T) {
 	tests := []struct {
 		Expected map[string]string


### PR DESCRIPTION
I ran into a nasty problem while changing a Cobra command from `flag` to a `persistentFlag`. The old code to bind the flag to viper did not error out after the new change, and allowed me to bind a wrapped empty flag. (details below)

This PR adds a check to make sure the passed in flag value is not `nil`. Without this check, a `nil` value gets wrapped in a new `pflagValue`, and later nil checks do not detect the problem.

More details: 

```
cmd.Flags().StringVarP(&myConfig, "myFlagName", ...
...
if err := viper.BindPFlag("myViperKey", cmd.Flags().Lookup("myFlagName")); err != nil { ...
```

When I changed the Cobra code to use a Persistent flag (as shown below), the viper.Bind call didn't notice any issue. The problem was the cmd.Flags.Lookup() was now returning nil. I needed to use cmd.PersistentFlags.Lookup() instead. It would have been helpful if Viper detected the nil parameter.
```
cmd.PersistentFlags().StringVarP(&myConfig, "myFlagName", ...
...
// would have been helpful if this call errored out
if err := viper.BindPFlag("myViperKey", cmd.Flags().Lookup("myFlagName")); err != nil { ...
// fixed call below
//if err := viper.BindPFlag("myViperKey", cmd.PersistentFlags().Lookup("myFlagName")); err != nil {...
```

