### PR TITLE
fix vulnerability: CVE-2020-15114 in etcd v3.3.13+incompatible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,3 +38,6 @@ require (
 	gopkg.in/ini.v1 v1.51.0
 	gopkg.in/yaml.v2 v2.2.4
 )
+
+// fix vulnerability: CVE-2020-15114 in etcd v3.3.13+incompatible
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.24+incompatible

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,7 @@ github.com/coreos/bbolt v1.3.2 h1:wZwiHHUieZCquLkDL0B8UhzreNWsPHooDAG3q34zk0s=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible h1:8F3hqu9fGYLBifCmRCJsicFqDx/D68Rt3q1JMazcgBQ=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
+github.com/coreos/etcd v3.3.24+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=


### PR DESCRIPTION
We're using Viper in [nancy](https://github.com/sonatype-nexus-community/nancy). Thanks so much for a great tool!

During a recent CI build, nancy discovered a vulnerability in a transitive dependency of Viper. This PR includes a `replace` directive to use a newly released update of that transitive dependency `etcd`. This transitive dep is pulled in by `github.com/bketelsen/crypt`.
```
$ go mod graph | grep coreos/etcd
github.com/bketelsen/crypt@v0.0.3-0.20200106085610-5cbc8cc4026c github.com/coreos/etcd@v3.3.13+incompatible
```

I submitted a [PR to crypt](https://github.com/bketelsen/crypt/pull/10), so hopefully there will soon be a non-vulnerable version of `crypt` available, to which Viper can upgrade. Meanwhile, this PR provides a way to use a non-vulnerable version of `etcd` if you like.