### PR TITLE
add parser

### DIFF
--- a/parsers.go
+++ b/parsers.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"strings"
+
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/printer"
 	"github.com/magiconair/properties"
@@ -12,8 +15,6 @@ import (
 	"github.com/subosito/gotenv"
 	"gopkg.in/ini.v1"
 	"gopkg.in/yaml.v2"
-	"io"
-	"strings"
 )
 
 var SupportedParsers map[string]Parser

--- a/parsers.go
+++ b/parsers.go
@@ -32,13 +32,13 @@ func AddParser(parser Parser, names ...string) {
 
 func parserInit() {
 	SupportedParsers = make(map[string]Parser, 32)
-	AddParser(&JsonParser{}, "json")
-	AddParser(&TomlParser{}, "toml")
-	AddParser(&YamlParser{}, "yaml", "yml")
-	AddParser(&PropsParser{}, "properties", "props", "prop")
-	AddParser(&HclParser{}, "hcl")
-	AddParser(&DotenvParser{}, "dotenv", "env")
-	AddParser(&IniParser{}, "ini")
+	AddParser(&JSONParser{}, "json")
+	AddParser(&TOMLParser{}, "toml")
+	AddParser(&YAMLParser{}, "yaml", "yml")
+	AddParser(&PROPSParser{}, "properties", "props", "prop")
+	AddParser(&HCLParser{}, "hcl")
+	AddParser(&DOTENVParser{}, "dotenv", "env")
+	AddParser(&INIParser{}, "ini")
 }
 
 func parserReset() {
@@ -46,15 +46,15 @@ func parserReset() {
 }
 
 // json parser
-type JsonParser struct {
+type JSONParser struct {
 }
 
-func (pp *JsonParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error {
+func (pp *JSONParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error {
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(in)
 	return json.Unmarshal(buf.Bytes(), &c)
 }
-func (pp *JsonParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
+func (pp *JSONParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
 	b, err := json.MarshalIndent(c, "", "  ")
 	if err != nil {
 		return err
@@ -64,10 +64,10 @@ func (pp *JsonParser) MarshalWriter(v *Viper, f afero.File, c map[string]interfa
 }
 
 // toml parser
-type TomlParser struct {
+type TOMLParser struct {
 }
 
-func (pp *TomlParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error {
+func (pp *TOMLParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error {
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(in)
 	tree, err := toml.LoadReader(buf)
@@ -80,7 +80,7 @@ func (pp *TomlParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]inter
 	}
 	return nil
 }
-func (pp *TomlParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
+func (pp *TOMLParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
 	t, err := toml.TreeFromMap(c)
 	if err != nil {
 		return err
@@ -93,15 +93,15 @@ func (pp *TomlParser) MarshalWriter(v *Viper, f afero.File, c map[string]interfa
 }
 
 // yaml parser
-type YamlParser struct {
+type YAMLParser struct {
 }
 
-func (pp *YamlParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error {
+func (pp *YAMLParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error {
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(in)
 	return yaml.Unmarshal(buf.Bytes(), &c)
 }
-func (pp *YamlParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
+func (pp *YAMLParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
 	b, err := yaml.Marshal(c)
 	if err != nil {
 		return err
@@ -113,10 +113,10 @@ func (pp *YamlParser) MarshalWriter(v *Viper, f afero.File, c map[string]interfa
 }
 
 // ini parser
-type IniParser struct {
+type INIParser struct {
 }
 
-func (pp *IniParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error {
+func (pp *INIParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error {
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(in)
 	cfg := ini.Empty()
@@ -136,7 +136,7 @@ func (pp *IniParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interf
 	}
 	return nil
 }
-func (pp *IniParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
+func (pp *INIParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
 	keys := v.AllKeys()
 	cfg := ini.Empty()
 	ini.PrettyFormat = false
@@ -155,10 +155,10 @@ func (pp *IniParser) MarshalWriter(v *Viper, f afero.File, c map[string]interfac
 }
 
 // hcl parser
-type HclParser struct {
+type HCLParser struct {
 }
 
-func (pp *HclParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error {
+func (pp *HCLParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error {
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(in)
 
@@ -171,7 +171,7 @@ func (pp *HclParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interf
 	}
 	return nil
 }
-func (pp *HclParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
+func (pp *HCLParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
 
 	b, err := json.Marshal(c)
 	if err != nil {
@@ -189,10 +189,10 @@ func (pp *HclParser) MarshalWriter(v *Viper, f afero.File, c map[string]interfac
 }
 
 // dot env parser
-type DotenvParser struct {
+type DOTENVParser struct {
 }
 
-func (pp *DotenvParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error {
+func (pp *DOTENVParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error {
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(in)
 
@@ -206,7 +206,7 @@ func (pp *DotenvParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]int
 
 	return nil
 }
-func (pp *DotenvParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
+func (pp *DOTENVParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
 	lines := []string{}
 	for _, key := range v.AllKeys() {
 		envName := strings.ToUpper(strings.Replace(key, ".", "_", -1))
@@ -221,10 +221,10 @@ func (pp *DotenvParser) MarshalWriter(v *Viper, f afero.File, c map[string]inter
 }
 
 // props parser
-type PropsParser struct {
+type PROPSParser struct {
 }
 
-func (pp *PropsParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error {
+func (pp *PROPSParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error {
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(in)
 
@@ -244,7 +244,7 @@ func (pp *PropsParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]inte
 	}
 	return nil
 }
-func (pp *PropsParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
+func (pp *PROPSParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
 	if v.properties == nil {
 		v.properties = properties.NewProperties()
 	}

--- a/parsers.go
+++ b/parsers.go
@@ -1,0 +1,263 @@
+package viper
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/hashicorp/hcl"
+	"github.com/hashicorp/hcl/hcl/printer"
+	"github.com/magiconair/properties"
+	"github.com/pelletier/go-toml"
+	"github.com/spf13/afero"
+	"github.com/subosito/gotenv"
+	"gopkg.in/ini.v1"
+	"gopkg.in/yaml.v2"
+	"io"
+	"strings"
+)
+
+var SupportedParsers map[string]Parser
+
+type Parser interface {
+	UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error // Unmarshal a Reader into a map.
+	MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error   // Marshal a map into Writer.
+}
+
+// add support parser
+func AddParser(parser Parser, names ...string) {
+	for _, n := range names {
+		SupportedParsers[n] = parser
+	}
+}
+
+func parserInit() {
+	SupportedParsers = make(map[string]Parser, 32)
+	AddParser(&JsonParser{}, "json")
+	AddParser(&TomlParser{}, "toml")
+	AddParser(&YamlParser{}, "yaml", "yml")
+	AddParser(&PropsParser{}, "properties", "props", "prop")
+	AddParser(&HclParser{}, "hcl")
+	AddParser(&DotenvParser{}, "dotenv", "env")
+	AddParser(&IniParser{}, "ini")
+}
+
+func parserReset() {
+	parserInit()
+}
+
+// json parser
+type JsonParser struct {
+}
+
+func (pp *JsonParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(in)
+	return json.Unmarshal(buf.Bytes(), &c)
+}
+func (pp *JsonParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
+	b, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = f.WriteString(string(b))
+	return err
+}
+
+// toml parser
+type TomlParser struct {
+}
+
+func (pp *TomlParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(in)
+	tree, err := toml.LoadReader(buf)
+	if err != nil {
+		return err
+	}
+	tmap := tree.ToMap()
+	for k, v := range tmap {
+		c[k] = v
+	}
+	return nil
+}
+func (pp *TomlParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
+	t, err := toml.TreeFromMap(c)
+	if err != nil {
+		return err
+	}
+	s := t.String()
+	if _, err := f.WriteString(s); err != nil {
+		return err
+	}
+	return nil
+}
+
+// yaml parser
+type YamlParser struct {
+}
+
+func (pp *YamlParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(in)
+	return yaml.Unmarshal(buf.Bytes(), &c)
+}
+func (pp *YamlParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
+	b, err := yaml.Marshal(c)
+	if err != nil {
+		return err
+	}
+	if _, err = f.WriteString(string(b)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ini parser
+type IniParser struct {
+}
+
+func (pp *IniParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(in)
+	cfg := ini.Empty()
+	err := cfg.Append(buf.Bytes())
+	if err != nil {
+		return err
+	}
+	sections := cfg.Sections()
+	for i := 0; i < len(sections); i++ {
+		section := sections[i]
+		keys := section.Keys()
+		for j := 0; j < len(keys); j++ {
+			key := keys[j]
+			value := cfg.Section(section.Name()).Key(key.Name()).String()
+			c[section.Name()+"."+key.Name()] = value
+		}
+	}
+	return nil
+}
+func (pp *IniParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
+	keys := v.AllKeys()
+	cfg := ini.Empty()
+	ini.PrettyFormat = false
+	for i := 0; i < len(keys); i++ {
+		key := keys[i]
+		lastSep := strings.LastIndex(key, ".")
+		sectionName := key[:(lastSep)]
+		keyName := key[(lastSep + 1):]
+		if sectionName == "default" {
+			sectionName = ""
+		}
+		cfg.Section(sectionName).Key(keyName).SetValue(v.Get(key).(string))
+	}
+	cfg.WriteTo(f)
+	return nil
+}
+
+// hcl parser
+type HclParser struct {
+}
+
+func (pp *HclParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(in)
+
+	obj, err := hcl.Parse(buf.String())
+	if err != nil {
+		return err
+	}
+	if err = hcl.DecodeObject(&c, obj); err != nil {
+		return err
+	}
+	return nil
+}
+func (pp *HclParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
+
+	b, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+	ast, err := hcl.Parse(string(b))
+	if err != nil {
+		return err
+	}
+	err = printer.Fprint(f, ast.Node)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// dot env parser
+type DotenvParser struct {
+}
+
+func (pp *DotenvParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(in)
+
+	env, err := gotenv.StrictParse(buf)
+	if err != nil {
+		return err
+	}
+	for k, v := range env {
+		c[k] = v
+	}
+
+	return nil
+}
+func (pp *DotenvParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
+	lines := []string{}
+	for _, key := range v.AllKeys() {
+		envName := strings.ToUpper(strings.Replace(key, ".", "_", -1))
+		val := v.Get(key)
+		lines = append(lines, fmt.Sprintf("%v=%v", envName, val))
+	}
+	s := strings.Join(lines, "\n")
+	if _, err := f.WriteString(s); err != nil {
+		return err
+	}
+	return nil
+}
+
+// props parser
+type PropsParser struct {
+}
+
+func (pp *PropsParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interface{}) error {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(in)
+
+	v.properties = properties.NewProperties()
+	var err error
+	if v.properties, err = properties.Load(buf.Bytes(), properties.UTF8); err != nil {
+		return ConfigParseError{err}
+	}
+	for _, key := range v.properties.Keys() {
+		value, _ := v.properties.Get(key)
+		// recursively build nested maps
+		path := strings.Split(key, ".")
+		lastKey := strings.ToLower(path[len(path)-1])
+		deepestMap := deepSearch(c, path[0:len(path)-1])
+		// set innermost value
+		deepestMap[lastKey] = value
+	}
+	return nil
+}
+func (pp *PropsParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
+	if v.properties == nil {
+		v.properties = properties.NewProperties()
+	}
+	p := v.properties
+	for _, key := range v.AllKeys() {
+		_, _, err := p.Set(key, v.GetString(key))
+		if err != nil {
+			return err
+		}
+	}
+	_, err := p.WriteComment(f, "#", properties.UTF8)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/parsers.go
+++ b/parsers.go
@@ -173,7 +173,6 @@ func (pp *HCLParser) UnmarshalReader(v *Viper, in io.Reader, c map[string]interf
 	return nil
 }
 func (pp *HCLParser) MarshalWriter(v *Viper, f afero.File, c map[string]interface{}) error {
-
 	b, err := json.Marshal(c)
 	if err != nil {
 		return err

--- a/viper.go
+++ b/viper.go
@@ -896,7 +896,6 @@ func Unmarshal(rawVal interface{}, opts ...DecoderConfigOption) error {
 	return v.Unmarshal(rawVal, opts...)
 }
 func (v *Viper) Unmarshal(rawVal interface{}, opts ...DecoderConfigOption) error {
-	fmt.Println(v.AllSettings())
 	return decode(v.AllSettings(), defaultDecoderConfig(rawVal, opts...))
 }
 


### PR DESCRIPTION
Add the interface of Parser. If the user wants to identify the user-defined configuration, such as XML, then the user can customize a parser and register it to process the customized configuration.