### PR TITLE
Update crypt to address CVE-2020-15114

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/spf13/viper
 go 1.12
 
 require (
-	github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c
+	github.com/bketelsen/crypt v0.0.3
 	github.com/coreos/bbolt v1.3.2 // indirect
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,12 +33,16 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c h1:+0HFd5KSZ/mm3JmhmrDukiId5iR6w4+BdFtfSy4yWIc=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
+github.com/bketelsen/crypt v0.0.3 h1:6bNynYE39IsvJHCLr6ziogOcIAec7LO6cuW/lwWGEWw=
+github.com/bketelsen/crypt v0.0.3/go.mod h1:XG4b7lkBbt44/SZ4QOtOjhd5SXJzF+pTJE+nWFY+Yqs=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2 h1:wZwiHHUieZCquLkDL0B8UhzreNWsPHooDAG3q34zk0s=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible h1:8F3hqu9fGYLBifCmRCJsicFqDx/D68Rt3q1JMazcgBQ=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
+github.com/coreos/etcd v3.3.24+incompatible h1:VTP6JXFEpcUyewV0VWQKC1dqeZ4mfq9SbRIyYvTq0nc=
+github.com/coreos/etcd v3.3.24+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=


### PR DESCRIPTION
Addresses [CVE-2020-15114](https://nvd.nist.gov/vuln/detail/CVE-2020-15114) by upgrading crypt. `nancy` returns no vulnerabilities:
```
go list -json -m all | nancy
 __  __
/\ \/\ \
\ \ `\\ \      __       ___      ___    __  __
 \ \ , ` \   /'__`\   /' _ `\   /'___\ /\ \/\ \
  \ \ \`\ \ /\ \L\.\_ /\ \/\ \ /\ \__/ \ \ \_\ \
   \ \_\ \_\\ \__/.\_\\ \_\ \_\\ \____\ \/`____ \
    \/_/\/_/ \/__/\/_/ \/_/\/_/ \/____/  `/___/> \
                                            /\___/
                                            \/__/
  _        _                           _    _
 /_)      /_` _  _  _ _/_     _  _    (/   /_` _ . _  _   _/  _
/_) /_/  ._/ /_// //_|/  /_/ /_//_'  (_X  /   / / /_'/ //_/ _\
    _/                   _/ /
Nancy version: 0.3.1

Non Vulnerable Packages

[1/155]	pkg:golang/cloud.google.com/go@0.46.3
[2/155]	pkg:golang/cloud.google.com/go/bigquery@1.0.1
[3/155]	pkg:golang/cloud.google.com/go/datastore@1.0.0
[4/155]	pkg:golang/cloud.google.com/go/firestore@1.1.0
[5/155]	pkg:golang/cloud.google.com/go/pubsub@1.0.1
[6/155]	pkg:golang/cloud.google.com/go/storage@1.0.0
[7/155]	pkg:golang/dmitri.shuralyov.com/gpu/mtl@0.0.0-20190408044501-666a987793e9
[8/155]	pkg:golang/github.com/BurntSushi/toml@0.3.1
[9/155]	pkg:golang/github.com/BurntSushi/xgb@0.0.0-20160522181843-27f122750802
[10/155]	pkg:golang/github.com/OneOfOne/xxhash@1.2.2
[11/155]	pkg:golang/github.com/alecthomas/template@0.0.0-20160405071501-a0175ee3bccc
[12/155]	pkg:golang/github.com/alecthomas/units@0.0.0-20151022065526-2efee857e7cf
[13/155]	pkg:golang/github.com/armon/circbuf@0.0.0-20150827004946-bbbad097214e
[14/155]	pkg:golang/github.com/armon/go-metrics@0.0.0-20180917152333-f0300d1749da
[15/155]	pkg:golang/github.com/armon/go-radix@0.0.0-20180808171621-7fddfc383310
[16/155]	pkg:golang/github.com/beorn7/perks@1.0.0
[17/155]	pkg:golang/github.com/bgentry/speakeasy@0.1.0
[18/155]	pkg:golang/github.com/bketelsen/crypt@0.0.3
[19/155]	pkg:golang/github.com/cespare/xxhash@1.1.0
[20/155]	pkg:golang/github.com/client9/misspell@0.3.4
[21/155]	pkg:golang/github.com/coreos/bbolt@1.3.2
[22/155]	pkg:golang/github.com/coreos/etcd@3.3.24
[23/155]	pkg:golang/github.com/coreos/go-semver@0.3.0
[24/155]	pkg:golang/github.com/coreos/go-systemd@0.0.0-20190321100706-95778dfbb74e
[25/155]	pkg:golang/github.com/coreos/pkg@0.0.0-20180928190104-399ea9e2e55f
[26/155]	pkg:golang/github.com/davecgh/go-spew@1.1.1
[27/155]	pkg:golang/github.com/dgrijalva/jwt-go@3.2.0
[28/155]	pkg:golang/github.com/dgryski/go-sip13@0.0.0-20181026042036-e10d5fee7954
[29/155]	pkg:golang/github.com/fatih/color@1.7.0
[30/155]	pkg:golang/github.com/fsnotify/fsnotify@1.4.7
[31/155]	pkg:golang/github.com/ghodss/yaml@1.0.0
[32/155]	pkg:golang/github.com/go-gl/glfw@0.0.0-20190409004039-e6da0acd62b1
[33/155]	pkg:golang/github.com/go-kit/kit@0.8.0
[34/155]	pkg:golang/github.com/go-logfmt/logfmt@0.4.0
[35/155]	pkg:golang/github.com/go-stack/stack@1.8.0
[36/155]	pkg:golang/github.com/gogo/protobuf@1.2.1
[37/155]	pkg:golang/github.com/golang/glog@0.0.0-20160126235308-23def4e6c14b
[38/155]	pkg:golang/github.com/golang/groupcache@0.0.0-20190129154638-5b532d6fd5ef
[39/155]	pkg:golang/github.com/golang/mock@1.3.1
[40/155]	pkg:golang/github.com/golang/protobuf@1.3.2
[41/155]	pkg:golang/github.com/google/btree@1.0.0
[42/155]	pkg:golang/github.com/google/go-cmp@0.3.0
[43/155]	pkg:golang/github.com/google/martian@2.1.0
[44/155]	pkg:golang/github.com/google/pprof@0.0.0-20190515194954-54271f7e092f
[45/155]	pkg:golang/github.com/google/renameio@0.1.0
[46/155]	pkg:golang/github.com/googleapis/gax-go/v2@2.0.5
[47/155]	pkg:golang/github.com/gopherjs/gopherjs@0.0.0-20181017120253-0766667cb4d1
[48/155]	pkg:golang/github.com/gorilla/websocket@1.4.2
[49/155]	pkg:golang/github.com/grpc-ecosystem/go-grpc-middleware@1.0.0
[50/155]	pkg:golang/github.com/grpc-ecosystem/go-grpc-prometheus@1.2.0
[51/155]	pkg:golang/github.com/grpc-ecosystem/grpc-gateway@1.9.0
[52/155]	pkg:golang/github.com/hashicorp/consul/api@1.1.0
[53/155]	pkg:golang/github.com/hashicorp/consul/sdk@0.1.1
[54/155]	pkg:golang/github.com/hashicorp/errwrap@1.0.0
[55/155]	pkg:golang/github.com/hashicorp/go-cleanhttp@0.5.1
[56/155]	pkg:golang/github.com/hashicorp/go-immutable-radix@1.0.0
[57/155]	pkg:golang/github.com/hashicorp/go-msgpack@0.5.3
[58/155]	pkg:golang/github.com/hashicorp/go-multierror@1.0.0
[59/155]	pkg:golang/github.com/hashicorp/go-rootcerts@1.0.0
[60/155]	pkg:golang/github.com/hashicorp/go-sockaddr@1.0.0
[61/155]	pkg:golang/github.com/hashicorp/go-syslog@1.0.0
[62/155]	pkg:golang/github.com/hashicorp/go-uuid@1.0.1
[63/155]	pkg:golang/github.com/hashicorp/go.net@0.0.1
[64/155]	pkg:golang/github.com/hashicorp/golang-lru@0.5.1
[65/155]	pkg:golang/github.com/hashicorp/hcl@1.0.0
[66/155]	pkg:golang/github.com/hashicorp/logutils@1.0.0
[67/155]	pkg:golang/github.com/hashicorp/mdns@1.0.0
[68/155]	pkg:golang/github.com/hashicorp/memberlist@0.1.3
[69/155]	pkg:golang/github.com/hashicorp/serf@0.8.2
[70/155]	pkg:golang/github.com/jonboulle/clockwork@0.1.0
[71/155]	pkg:golang/github.com/json-iterator/go@1.1.6
[72/155]	pkg:golang/github.com/jstemmer/go-junit-report@0.0.0-20190106144839-af01ea7f8024
[73/155]	pkg:golang/github.com/jtolds/gls@4.20.0
[74/155]	pkg:golang/github.com/julienschmidt/httprouter@1.2.0
[75/155]	pkg:golang/github.com/kisielk/errcheck@1.1.0
[76/155]	pkg:golang/github.com/kisielk/gotool@1.0.0
[77/155]	pkg:golang/github.com/konsorten/go-windows-terminal-sequences@1.0.1
[78/155]	pkg:golang/github.com/kr/logfmt@0.0.0-20140226030751-b84e30acd515
[79/155]	pkg:golang/github.com/kr/pretty@0.1.0
[80/155]	pkg:golang/github.com/kr/pty@1.1.1
[81/155]	pkg:golang/github.com/kr/text@0.1.0
[82/155]	pkg:golang/github.com/magiconair/properties@1.8.1
[83/155]	pkg:golang/github.com/mattn/go-colorable@0.0.9
[84/155]	pkg:golang/github.com/mattn/go-isatty@0.0.3
[85/155]	pkg:golang/github.com/matttproud/golang_protobuf_extensions@1.0.1
[86/155]	pkg:golang/github.com/miekg/dns@1.0.14
[87/155]	pkg:golang/github.com/mitchellh/cli@1.0.0
[88/155]	pkg:golang/github.com/mitchellh/go-homedir@1.0.0
[89/155]	pkg:golang/github.com/mitchellh/go-testing-interface@1.0.0
[90/155]	pkg:golang/github.com/mitchellh/gox@0.4.0
[91/155]	pkg:golang/github.com/mitchellh/iochan@1.0.0
[92/155]	pkg:golang/github.com/mitchellh/mapstructure@1.1.2
[93/155]	pkg:golang/github.com/modern-go/concurrent@0.0.0-20180306012644-bacd9c7ef1dd
[94/155]	pkg:golang/github.com/modern-go/reflect2@1.0.1
[95/155]	pkg:golang/github.com/mwitkow/go-conntrack@0.0.0-20161129095857-cc309e4a2223
[96/155]	pkg:golang/github.com/oklog/ulid@1.3.1
[97/155]	pkg:golang/github.com/pascaldekloe/goe@0.0.0-20180627143212-57f6aae5913c
[98/155]	pkg:golang/github.com/pelletier/go-toml@1.2.0
[99/155]	pkg:golang/github.com/pkg/errors@0.8.1
[100/155]	pkg:golang/github.com/pmezard/go-difflib@1.0.0
[101/155]	pkg:golang/github.com/posener/complete@1.1.1
[102/155]	pkg:golang/github.com/prometheus/client_golang@0.9.3
[103/155]	pkg:golang/github.com/prometheus/client_model@0.0.0-20190129233127-fd36f4220a90
[104/155]	pkg:golang/github.com/prometheus/common@0.4.0
[105/155]	pkg:golang/github.com/prometheus/procfs@0.0.0-20190507164030-5867b95ac084
[106/155]	pkg:golang/github.com/prometheus/tsdb@0.7.1
[107/155]	pkg:golang/github.com/rogpeppe/fastuuid@0.0.0-20150106093220-6724a57986af
[108/155]	pkg:golang/github.com/rogpeppe/go-internal@1.3.0
[109/155]	pkg:golang/github.com/ryanuber/columnize@0.0.0-20160712163229-9b3edd62028f
[110/155]	pkg:golang/github.com/sean-/seed@0.0.0-20170313163322-e2103e2c3529
[111/155]	pkg:golang/github.com/sirupsen/logrus@1.2.0
[112/155]	pkg:golang/github.com/smartystreets/assertions@0.0.0-20180927180507-b2de0cb4f26d
[113/155]	pkg:golang/github.com/smartystreets/goconvey@1.6.4
[114/155]	pkg:golang/github.com/soheilhy/cmux@0.1.4
[115/155]	pkg:golang/github.com/spaolacci/murmur3@0.0.0-20180118202830-f09979ecbc72
[116/155]	pkg:golang/github.com/spf13/afero@1.1.2
[117/155]	pkg:golang/github.com/spf13/cast@1.3.0
[118/155]	pkg:golang/github.com/spf13/jwalterweatherman@1.0.0
[119/155]	pkg:golang/github.com/spf13/pflag@1.0.3
[120/155]	pkg:golang/github.com/stretchr/objx@0.1.1
[121/155]	pkg:golang/github.com/stretchr/testify@1.3.0
[122/155]	pkg:golang/github.com/subosito/gotenv@1.2.0
[123/155]	pkg:golang/github.com/tmc/grpc-websocket-proxy@0.0.0-20190109142713-0ad062ec5ee5
[124/155]	pkg:golang/github.com/xiang90/probing@0.0.0-20190116061207-43a291ad63a2
[125/155]	pkg:golang/go.etcd.io/bbolt@1.3.2
[126/155]	pkg:golang/go.opencensus.io@0.22.0
[127/155]	pkg:golang/go.uber.org/atomic@1.4.0
[128/155]	pkg:golang/go.uber.org/multierr@1.1.0
[129/155]	pkg:golang/go.uber.org/zap@1.10.0
[130/155]	pkg:golang/golang.org/x/crypto@0.0.0-20190605123033-f99c8df09eb5
[131/155]	pkg:golang/golang.org/x/exp@0.0.0-20191030013958-a1ab85dbe136
[132/155]	pkg:golang/golang.org/x/image@0.0.0-20190802002840-cff245a6509b
[133/155]	pkg:golang/golang.org/x/lint@0.0.0-20190930215403-16217165b5de
[134/155]	pkg:golang/golang.org/x/mobile@0.0.0-20190719004257-d2bd2a29d028
[135/155]	pkg:golang/golang.org/x/mod@0.1.0
[136/155]	pkg:golang/golang.org/x/net@0.0.0-20190620200207-3b0461eec859
[137/155]	pkg:golang/golang.org/x/oauth2@0.0.0-20190604053449-0f29369cfe45
[138/155]	pkg:golang/golang.org/x/sync@0.0.0-20190423024810-112230192c58
[139/155]	pkg:golang/golang.org/x/sys@0.0.0-20190624142023-c5567b49c5d0
[140/155]	pkg:golang/golang.org/x/text@0.3.2
[141/155]	pkg:golang/golang.org/x/time@0.0.0-20190308202827-9d24e82272b4
[142/155]	pkg:golang/golang.org/x/tools@0.0.0-20191112195655-aa38f8e97acc
[143/155]	pkg:golang/golang.org/x/xerrors@0.0.0-20190717185122-a985d3407aa7
[144/155]	pkg:golang/google.golang.org/api@0.13.0
[145/155]	pkg:golang/google.golang.org/appengine@1.6.1
[146/155]	pkg:golang/google.golang.org/genproto@0.0.0-20191108220845-16a3f7862a1a
[147/155]	pkg:golang/google.golang.org/grpc@1.21.1
[148/155]	pkg:golang/github.com/alecthomas/kingpin@2.2.6
[149/155]	pkg:golang/github.com/go-check/check@1.0.0-20180628173108-788fd7840127
[150/155]	pkg:golang/github.com/go-errgo/errgo@2.1.0
[151/155]	pkg:golang/github.com/go-ini/ini@1.51.0
[152/155]	pkg:golang/github.com/go-resty/resty@1.12.0
[153/155]	pkg:golang/github.com/go-yaml/yaml@2.2.4
[154/155]	pkg:golang/honnef.co/go/tools@0.0.1-2019.2.3
[155/155]	pkg:golang/rsc.io/binaryregexp@0.2.0
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Summary                       ┃
┣━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━┫
┃ Audited Dependencies    ┃ 155 ┃
┣━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━┫
┃ Vulnerable Dependencies ┃ 0   ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━┛
```