### PR TITLE
Fix the ReadInConfig return when using SetConfigFile

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -2038,6 +2038,10 @@ func (v *Viper) getConfigFile() (string, error) {
 			return "", err
 		}
 		v.configFile = cf
+	} else {
+		if b, _ := exists(v.fs, v.configFile); !b {
+			return "", ConfigFileNotFoundError{"", v.configFile}
+		}
 	}
 	return v.configFile, nil
 }

--- a/viper_test.go
+++ b/viper_test.go
@@ -301,9 +301,11 @@ func (s *stringValue) String() string {
 
 func TestBasics(t *testing.T) {
 	SetConfigFile("/tmp/config.yaml")
-	filename, err := v.getConfigFile()
-	assert.Equal(t, "/tmp/config.yaml", filename)
-	assert.NoError(t, err)
+	_, err := v.getConfigFile()
+	assert.Error(t, err)
+	err = ReadInConfig()
+	_, ok := err.(ConfigFileNotFoundError)
+	assert.True(t, ok)
 }
 
 func TestSearchInPath_WithoutConfigTypeSet(t *testing.T) {


### PR DESCRIPTION
The traditional program only uses one absolute configure file path
with using SetConfigFile().

If the file doesn't exist, return ConfigFileNotFoundError.

Signed-off-by: Li Feng <lifeng1519@gmail.com>