### PR TITLE
viper.searchInPath matching files with no ext

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -2119,7 +2119,7 @@ func (v *Viper) searchInPath(in string) (filename string) {
 		}
 	}
 
-	if v.configType != "" {
+	if v.configType == "" {
 		if b, _ := exists(v.fs, filepath.Join(in, v.configName)); b {
 			return filepath.Join(in, v.configName)
 		}


### PR DESCRIPTION
I think if the user is setting config type explicitly, we shouldn't be matching it with non-ext files but doing it when the extension is not provided.
For example: If I have used my config file name as "something" and set ".yaml" as config type, it will actually match my compiled binary with the name "something" if no "something.yaml" is found. 