### PR TITLE
Support and test envPrefix on Sub

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -851,6 +851,7 @@ func (v *Viper) Sub(key string) *Viper {
 	if reflect.TypeOf(data).Kind() == reflect.Map {
 		subv.parents = append(v.parents, strings.ToLower(key))
 		subv.automaticEnvApplied = v.automaticEnvApplied
+		subv.envPrefix = v.envPrefix
 		subv.envKeyReplacer = v.envKeyReplacer
 		subv.config = cast.ToStringMap(data)
 		return subv

--- a/viper_test.go
+++ b/viper_test.go
@@ -609,12 +609,17 @@ func TestEnvSubConfig(t *testing.T) {
 
 	v.AutomaticEnv()
 
-	replacer := strings.NewReplacer(".", "_")
-	v.SetEnvKeyReplacer(replacer)
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 
 	testutil.Setenv(t, "CLOTHING_PANTS_SIZE", "small")
 	subv := v.Sub("clothing").Sub("pants")
 	assert.Equal(t, "small", subv.Get("size"))
+
+	// again with EnvPrefix
+	v.SetEnvPrefix("foo") // will be uppercased automatically
+	subWithPrefix := v.Sub("clothing").Sub("pants")
+	testutil.Setenv(t, "FOO_CLOTHING_PANTS_SIZE", "large")
+	assert.Equal(t, "large", subWithPrefix.Get("size"))
 }
 
 func TestAllKeys(t *testing.T) {


### PR DESCRIPTION
This builds on #1056 and adds support and tests for EnvPrefix using Sub with AutomaticEnv

> @TaylorOno commented on Dec 24, 2020
This PR fixes two issues with Sub():
Options were not copied from parent (e.g, automaticEnvApplied).
Environment variable names were wrong: Sub("x").Sub("y").Get("z") should look up env var x.y.z but was instead looking up z

Probably fixes:
#745
#507
#1012 (partial)
#801 (partial) 