### PR TITLE
add nancy scan to CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,9 @@ jobs:
 
       - name: Test
         run: make test
+
+      - name: WriteGoList
+        run: go list -json -m all > go.list
+
+      - name: Nancy scan
+        uses: sonatype-nexus-community/nancy-github-action@main


### PR DESCRIPTION
Runs [nancy](https://github.com/sonatype-nexus-community/nancy) to scan for vulnerabilities as part of the CI build.

relates to PR #961 and PR #1066 in that those PR's should fix the build failures.