### PR TITLE
update %s to %w

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ viper.AddConfigPath("$HOME/.appname")  // call multiple times to add many search
 viper.AddConfigPath(".")               // optionally look for config in the working directory
 err := viper.ReadInConfig() // Find and read the config file
 if err != nil { // Handle errors reading the config file
-	panic(fmt.Errorf("Fatal error config file: %s \n", err))
+	panic(fmt.Errorf("Fatal error config file: %w \n", err))
 }
 ```
 


### PR DESCRIPTION
I apologize for my rude pr on modify readme
I think it is better to use %w in fmt.Errorf instead of %s
[go error doc](https://golang.org/pkg/errors/)