### PR TITLE
Make sure Viper compiles on WASM

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,26 @@
+name: WASM
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    env:
+      GOFLAGS: -mod=readonly
+
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Ensure Viper compiles for WASM
+        run: GOOS=js GOARCH=wasm go build .

--- a/viper.go
+++ b/viper.go
@@ -344,7 +344,7 @@ func (v *Viper) WatchConfig() {
 	initWG := sync.WaitGroup{}
 	initWG.Add(1)
 	go func() {
-		watcher, err := fsnotify.NewWatcher()
+		watcher, err := newWatcher()
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/watch.go
+++ b/watch.go
@@ -1,0 +1,11 @@
+// +build !js
+
+package viper
+
+import "github.com/fsnotify/fsnotify"
+
+type watcher = fsnotify.Watcher
+
+func newWatcher() (*watcher, error) {
+	return fsnotify.NewWatcher()
+}

--- a/watch_wasm.go
+++ b/watch_wasm.go
@@ -1,0 +1,30 @@
+// +build js,wasm
+
+package viper
+
+import (
+	"errors"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+type watcher struct {
+	Events chan fsnotify.Event
+	Errors chan error
+}
+
+func (*watcher) Close() error {
+	return nil
+}
+
+func (*watcher) Add(name string) error {
+	return nil
+}
+
+func (*watcher) Remove(name string) error {
+	return nil
+}
+
+func newWatcher() (*watcher, error) {
+	return &watcher{}, errors.New("fsnotify is not supported on WASM")
+}


### PR DESCRIPTION
fsnotify is not available on WASM,
so config watching is not going to work.

Fixes #1071