### PR TITLE
Fix merging a key into a nil target

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1826,7 +1826,7 @@ func mergeMaps(
 
 		svType := reflect.TypeOf(sv)
 		tvType := reflect.TypeOf(tv)
-		if svType != tvType {
+		if tvType != nil && svType != tvType { // Allow for the target to be nil
 			jww.ERROR.Printf(
 				"svType != tvType; key=%s, st=%v, tt=%v, sv=%v, tv=%v",
 				sk, svType, tvType, sv, tv)

--- a/viper_test.go
+++ b/viper_test.go
@@ -1695,6 +1695,7 @@ hello:
     pop: 37890
     largenum: 765432101234567
     num2pow63: 9223372036854775808
+    universe: null
     world:
     - us
     - uk


### PR DESCRIPTION
When merging a key where the target value is nil, the type of the target and source do not match. What currently happens is an error is logged and the key is skipped.

I have changed it so that it does the same thing as when the target key is missing: copy the source value to the target.

Fixes #1134 