### PR TITLE
Improve encoding layer

### DIFF
--- a/internal/encoding/decoder.go
+++ b/internal/encoding/decoder.go
@@ -4,10 +4,10 @@ import (
 	"sync"
 )
 
-// Decoder decodes the contents of b into a v representation.
+// Decoder decodes the contents of b into v.
 // It's primarily used for decoding contents of a file into a map[string]interface{}.
 type Decoder interface {
-	Decode(b []byte, v interface{}) error
+	Decode(b []byte, v map[string]interface{}) error
 }
 
 const (
@@ -48,7 +48,7 @@ func (e *DecoderRegistry) RegisterDecoder(format string, enc Decoder) error {
 }
 
 // Decode calls the underlying Decoder based on the format.
-func (e *DecoderRegistry) Decode(format string, b []byte, v interface{}) error {
+func (e *DecoderRegistry) Decode(format string, b []byte, v map[string]interface{}) error {
 	e.mu.RLock()
 	decoder, ok := e.decoders[format]
 	e.mu.RUnlock()

--- a/internal/encoding/decoder_test.go
+++ b/internal/encoding/decoder_test.go
@@ -1,16 +1,18 @@
 package encoding
 
 import (
+	"reflect"
 	"testing"
 )
 
 type decoder struct {
-	v interface{}
+	v map[string]interface{}
 }
 
-func (d decoder) Decode(_ []byte, v interface{}) error {
-	rv := v.(*string)
-	*rv = d.v.(string)
+func (d decoder) Decode(_ []byte, v map[string]interface{}) error {
+	for key, value := range d.v {
+		v[key] = value
+	}
 
 	return nil
 }
@@ -44,7 +46,9 @@ func TestDecoderRegistry_Decode(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		registry := NewDecoderRegistry()
 		decoder := decoder{
-			v: "decoded value",
+			v: map[string]interface{}{
+				"key": "value",
+			},
 		}
 
 		err := registry.RegisterDecoder("myformat", decoder)
@@ -52,24 +56,24 @@ func TestDecoderRegistry_Decode(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		var v string
+		v := map[string]interface{}{}
 
-		err = registry.Decode("myformat", []byte("some value"), &v)
+		err = registry.Decode("myformat", []byte("key: value"), v)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if v != "decoded value" {
-			t.Fatalf("expected 'decoded value', got: %#v", v)
+		if !reflect.DeepEqual(decoder.v, v) {
+			t.Fatalf("decoded value does not match the expected one\nactual:   %+v\nexpected: %+v", v, decoder.v)
 		}
 	})
 
 	t.Run("DecoderNotFound", func(t *testing.T) {
 		registry := NewDecoderRegistry()
 
-		var v string
+		v := map[string]interface{}{}
 
-		err := registry.Decode("myformat", []byte("some value"), &v)
+		err := registry.Decode("myformat", nil, v)
 		if err != ErrDecoderNotFound {
 			t.Fatalf("expected ErrDecoderNotFound, got: %v", err)
 		}

--- a/internal/encoding/dotenv/codec.go
+++ b/internal/encoding/dotenv/codec.go
@@ -1,0 +1,61 @@
+package dotenv
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/subosito/gotenv"
+)
+
+const keyDelimiter = "_"
+
+// Codec implements the encoding.Encoder and encoding.Decoder interfaces for encoding data containing environment variables
+// (commonly called as dotenv format).
+type Codec struct{}
+
+func (Codec) Encode(v map[string]interface{}) ([]byte, error) {
+	flattened := map[string]interface{}{}
+
+	flattened = flattenAndMergeMap(flattened, v, "", keyDelimiter)
+
+	keys := make([]string, 0, len(flattened))
+
+	for key := range flattened {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	var buf bytes.Buffer
+
+	for _, key := range keys {
+		_, err := buf.WriteString(fmt.Sprintf("%v=%v\n", strings.ToUpper(key), flattened[key]))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (Codec) Decode(b []byte, v map[string]interface{}) error {
+	var buf bytes.Buffer
+
+	_, err := buf.Write(b)
+	if err != nil {
+		return err
+	}
+
+	env, err := gotenv.StrictParse(&buf)
+	if err != nil {
+		return err
+	}
+
+	for key, value := range env {
+		v[key] = value
+	}
+
+	return nil
+}

--- a/internal/encoding/dotenv/codec_test.go
+++ b/internal/encoding/dotenv/codec_test.go
@@ -1,0 +1,63 @@
+package dotenv
+
+import (
+	"reflect"
+	"testing"
+)
+
+// original form of the data
+const original = `# key-value pair
+KEY=value
+`
+
+// encoded form of the data
+const encoded = `KEY=value
+`
+
+// Viper's internal representation
+var data = map[string]interface{}{
+	"KEY": "value",
+}
+
+func TestCodec_Encode(t *testing.T) {
+	codec := Codec{}
+
+	b, err := codec.Encode(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if encoded != string(b) {
+		t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", string(b), encoded)
+	}
+}
+
+func TestCodec_Decode(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		codec := Codec{}
+
+		v := map[string]interface{}{}
+
+		err := codec.Decode([]byte(original), v)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(data, v) {
+			t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", v, data)
+		}
+	})
+
+	t.Run("InvalidData", func(t *testing.T) {
+		codec := Codec{}
+
+		v := map[string]interface{}{}
+
+		err := codec.Decode([]byte(`invalid data`), v)
+		if err == nil {
+			t.Fatal("expected decoding to fail")
+		}
+
+		t.Logf("decoding failed as expected: %s", err)
+	})
+}

--- a/internal/encoding/dotenv/map_utils.go
+++ b/internal/encoding/dotenv/map_utils.go
@@ -1,0 +1,41 @@
+package dotenv
+
+import (
+	"strings"
+
+	"github.com/spf13/cast"
+)
+
+// flattenAndMergeMap recursively flattens the given map into a new map
+// Code is based on the function with the same name in tha main package.
+// TODO: move it to a common place
+func flattenAndMergeMap(shadow map[string]interface{}, m map[string]interface{}, prefix string, delimiter string) map[string]interface{} {
+	if shadow != nil && prefix != "" && shadow[prefix] != nil {
+		// prefix is shadowed => nothing more to flatten
+		return shadow
+	}
+	if shadow == nil {
+		shadow = make(map[string]interface{})
+	}
+
+	var m2 map[string]interface{}
+	if prefix != "" {
+		prefix += delimiter
+	}
+	for k, val := range m {
+		fullKey := prefix + k
+		switch val.(type) {
+		case map[string]interface{}:
+			m2 = val.(map[string]interface{})
+		case map[interface{}]interface{}:
+			m2 = cast.ToStringMap(val)
+		default:
+			// immediate value
+			shadow[strings.ToLower(fullKey)] = val
+			continue
+		}
+		// recursively merge to shadow map
+		shadow = flattenAndMergeMap(shadow, m2, fullKey, delimiter)
+	}
+	return shadow
+}

--- a/internal/encoding/encoder.go
+++ b/internal/encoding/encoder.go
@@ -7,7 +7,7 @@ import (
 // Encoder encodes the contents of v into a byte representation.
 // It's primarily used for encoding a map[string]interface{} into a file format.
 type Encoder interface {
-	Encode(v interface{}) ([]byte, error)
+	Encode(v map[string]interface{}) ([]byte, error)
 }
 
 const (
@@ -47,7 +47,7 @@ func (e *EncoderRegistry) RegisterEncoder(format string, enc Encoder) error {
 	return nil
 }
 
-func (e *EncoderRegistry) Encode(format string, v interface{}) ([]byte, error) {
+func (e *EncoderRegistry) Encode(format string, v map[string]interface{}) ([]byte, error) {
 	e.mu.RLock()
 	encoder, ok := e.encoders[format]
 	e.mu.RUnlock()

--- a/internal/encoding/encoder_test.go
+++ b/internal/encoding/encoder_test.go
@@ -8,7 +8,7 @@ type encoder struct {
 	b []byte
 }
 
-func (e encoder) Encode(_ interface{}) ([]byte, error) {
+func (e encoder) Encode(_ map[string]interface{}) ([]byte, error) {
 	return e.b, nil
 }
 
@@ -41,7 +41,7 @@ func TestEncoderRegistry_Decode(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		registry := NewEncoderRegistry()
 		encoder := encoder{
-			b: []byte("encoded value"),
+			b: []byte("key: value"),
 		}
 
 		err := registry.RegisterEncoder("myformat", encoder)
@@ -49,20 +49,20 @@ func TestEncoderRegistry_Decode(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		b, err := registry.Encode("myformat", "some value")
+		b, err := registry.Encode("myformat", map[string]interface{}{"key": "value"})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if string(b) != "encoded value" {
-			t.Fatalf("expected 'encoded value', got: %#v", string(b))
+		if string(b) != "key: value" {
+			t.Fatalf("expected 'key: value', got: %#v", string(b))
 		}
 	})
 
 	t.Run("EncoderNotFound", func(t *testing.T) {
 		registry := NewEncoderRegistry()
 
-		_, err := registry.Encode("myformat", "some value")
+		_, err := registry.Encode("myformat", map[string]interface{}{"key": "value"})
 		if err != ErrEncoderNotFound {
 			t.Fatalf("expected ErrEncoderNotFound, got: %v", err)
 		}

--- a/internal/encoding/hcl/codec.go
+++ b/internal/encoding/hcl/codec.go
@@ -12,7 +12,7 @@ import (
 // TODO: add printer config to the codec?
 type Codec struct{}
 
-func (Codec) Encode(v interface{}) ([]byte, error) {
+func (Codec) Encode(v map[string]interface{}) ([]byte, error) {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return nil, err

--- a/internal/encoding/hcl/codec.go
+++ b/internal/encoding/hcl/codec.go
@@ -35,6 +35,6 @@ func (Codec) Encode(v interface{}) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func (Codec) Decode(b []byte, v interface{}) error {
-	return hcl.Unmarshal(b, v)
+func (Codec) Decode(b []byte, v map[string]interface{}) error {
+	return hcl.Unmarshal(b, &v)
 }

--- a/internal/encoding/hcl/codec_test.go
+++ b/internal/encoding/hcl/codec_test.go
@@ -1,0 +1,140 @@
+package hcl
+
+import (
+	"reflect"
+	"testing"
+)
+
+// original form of the data
+const original = `# key-value pair
+"key" = "value"
+
+// list
+"list" = ["item1", "item2", "item3"]
+
+/* map */
+"map" = {
+  "key" = "value"
+}
+
+/*
+nested map
+*/
+"nested_map" "map" {
+  "key" = "value"
+
+  "list" = ["item1", "item2", "item3"]
+}`
+
+// encoded form of the data
+const encoded = `"key" = "value"
+
+"list" = ["item1", "item2", "item3"]
+
+"map" = {
+  "key" = "value"
+}
+
+"nested_map" "map" {
+  "key" = "value"
+
+  "list" = ["item1", "item2", "item3"]
+}`
+
+// decoded form of the data
+//
+// in case of HCL it's slightly different from Viper's internal representation
+// (eg. map is decoded into a list of maps)
+var decoded = map[string]interface{}{
+	"key": "value",
+	"list": []interface{}{
+		"item1",
+		"item2",
+		"item3",
+	},
+	"map": []map[string]interface{}{
+		{
+			"key": "value",
+		},
+	},
+	"nested_map": []map[string]interface{}{
+		{
+			"map": []map[string]interface{}{
+				{
+					"key": "value",
+					"list": []interface{}{
+						"item1",
+						"item2",
+						"item3",
+					},
+				},
+			},
+		},
+	},
+}
+
+// Viper's internal representation
+var data = map[string]interface{}{
+	"key": "value",
+	"list": []interface{}{
+		"item1",
+		"item2",
+		"item3",
+	},
+	"map": map[string]interface{}{
+		"key": "value",
+	},
+	"nested_map": map[string]interface{}{
+		"map": map[string]interface{}{
+			"key": "value",
+			"list": []interface{}{
+				"item1",
+				"item2",
+				"item3",
+			},
+		},
+	},
+}
+
+func TestCodec_Encode(t *testing.T) {
+	codec := Codec{}
+
+	b, err := codec.Encode(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if encoded != string(b) {
+		t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", string(b), encoded)
+	}
+}
+
+func TestCodec_Decode(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		codec := Codec{}
+
+		v := map[string]interface{}{}
+
+		err := codec.Decode([]byte(original), v)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(decoded, v) {
+			t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", v, decoded)
+		}
+	})
+
+	t.Run("InvalidData", func(t *testing.T) {
+		codec := Codec{}
+
+		v := map[string]interface{}{}
+
+		err := codec.Decode([]byte(`invalid data`), v)
+		if err == nil {
+			t.Fatal("expected decoding to fail")
+		}
+
+		t.Logf("decoding failed as expected: %s", err)
+	})
+}

--- a/internal/encoding/ini/codec.go
+++ b/internal/encoding/ini/codec.go
@@ -1,0 +1,99 @@
+package ini
+
+import (
+	"bytes"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cast"
+	"gopkg.in/ini.v1"
+)
+
+// LoadOptions contains all customized options used for load data source(s).
+// This type is added here for convenience: this way consumers can import a single package called "ini".
+type LoadOptions = ini.LoadOptions
+
+// Codec implements the encoding.Encoder and encoding.Decoder interfaces for INI encoding.
+type Codec struct {
+	KeyDelimiter string
+	LoadOptions  LoadOptions
+}
+
+func (c Codec) Encode(v map[string]interface{}) ([]byte, error) {
+	cfg := ini.Empty()
+	ini.PrettyFormat = false
+
+	flattened := map[string]interface{}{}
+
+	flattened = flattenAndMergeMap(flattened, v, "", c.keyDelimiter())
+
+	keys := make([]string, 0, len(flattened))
+
+	for key := range flattened {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		sectionName, keyName := "", key
+
+		lastSep := strings.LastIndex(key, ".")
+		if lastSep != -1 {
+			sectionName = key[:(lastSep)]
+			keyName = key[(lastSep + 1):]
+		}
+
+		// TODO: is this a good idea?
+		if sectionName == "default" {
+			sectionName = ""
+		}
+
+		cfg.Section(sectionName).Key(keyName).SetValue(cast.ToString(flattened[key]))
+	}
+
+	var buf bytes.Buffer
+
+	_, err := cfg.WriteTo(&buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (c Codec) Decode(b []byte, v map[string]interface{}) error {
+	cfg := ini.Empty(c.LoadOptions)
+
+	err := cfg.Append(b)
+	if err != nil {
+		return err
+	}
+
+	sections := cfg.Sections()
+
+	for i := 0; i < len(sections); i++ {
+		section := sections[i]
+		keys := section.Keys()
+
+		for j := 0; j < len(keys); j++ {
+			key := keys[j]
+			value := cfg.Section(section.Name()).Key(key.Name()).String()
+
+			deepestMap := deepSearch(v, strings.Split(section.Name(), c.keyDelimiter()))
+
+			// set innermost value
+			deepestMap[key.Name()] = value
+		}
+	}
+
+	return nil
+}
+
+func (c Codec) keyDelimiter() string {
+	if c.KeyDelimiter == "" {
+		return "."
+	}
+
+	return c.KeyDelimiter
+}

--- a/internal/encoding/ini/codec_test.go
+++ b/internal/encoding/ini/codec_test.go
@@ -1,0 +1,112 @@
+package ini
+
+import (
+	"reflect"
+	"testing"
+)
+
+// original form of the data
+const original = `; key-value pair
+key=value ; key-value pair
+
+# map
+[map] # map
+key=%(key)s
+
+`
+
+// encoded form of the data
+const encoded = `key=value
+
+[map]
+key=value
+
+`
+
+// decoded form of the data
+//
+// in case of INI it's slightly different from Viper's internal representation
+// (eg. top level keys land in a section called default)
+var decoded = map[string]interface{}{
+	"DEFAULT": map[string]interface{}{
+		"key": "value",
+	},
+	"map": map[string]interface{}{
+		"key": "value",
+	},
+}
+
+// Viper's internal representation
+var data = map[string]interface{}{
+	"key": "value",
+	"map": map[string]interface{}{
+		"key": "value",
+	},
+}
+
+func TestCodec_Encode(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		codec := Codec{}
+
+		b, err := codec.Encode(data)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if encoded != string(b) {
+			t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", string(b), encoded)
+		}
+	})
+
+	t.Run("Default", func(t *testing.T) {
+		codec := Codec{}
+
+		data := map[string]interface{}{
+			"default": map[string]interface{}{
+				"key": "value",
+			},
+			"map": map[string]interface{}{
+				"key": "value",
+			},
+		}
+
+		b, err := codec.Encode(data)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if encoded != string(b) {
+			t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", string(b), encoded)
+		}
+	})
+}
+
+func TestCodec_Decode(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		codec := Codec{}
+
+		v := map[string]interface{}{}
+
+		err := codec.Decode([]byte(original), v)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(decoded, v) {
+			t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", v, decoded)
+		}
+	})
+
+	t.Run("InvalidData", func(t *testing.T) {
+		codec := Codec{}
+
+		v := map[string]interface{}{}
+
+		err := codec.Decode([]byte(`invalid data`), v)
+		if err == nil {
+			t.Fatal("expected decoding to fail")
+		}
+
+		t.Logf("decoding failed as expected: %s", err)
+	})
+}

--- a/internal/encoding/ini/map_utils.go
+++ b/internal/encoding/ini/map_utils.go
@@ -1,0 +1,74 @@
+package ini
+
+import (
+	"strings"
+
+	"github.com/spf13/cast"
+)
+
+// THIS CODE IS COPIED HERE: IT SHOULD NOT BE MODIFIED
+// AT SOME POINT IT WILL BE MOVED TO A COMMON PLACE
+// deepSearch scans deep maps, following the key indexes listed in the
+// sequence "path".
+// The last value is expected to be another map, and is returned.
+//
+// In case intermediate keys do not exist, or map to a non-map value,
+// a new map is created and inserted, and the search continues from there:
+// the initial map "m" may be modified!
+func deepSearch(m map[string]interface{}, path []string) map[string]interface{} {
+	for _, k := range path {
+		m2, ok := m[k]
+		if !ok {
+			// intermediate key does not exist
+			// => create it and continue from there
+			m3 := make(map[string]interface{})
+			m[k] = m3
+			m = m3
+			continue
+		}
+		m3, ok := m2.(map[string]interface{})
+		if !ok {
+			// intermediate key is a value
+			// => replace with a new map
+			m3 = make(map[string]interface{})
+			m[k] = m3
+		}
+		// continue search from here
+		m = m3
+	}
+	return m
+}
+
+// flattenAndMergeMap recursively flattens the given map into a new map
+// Code is based on the function with the same name in tha main package.
+// TODO: move it to a common place
+func flattenAndMergeMap(shadow map[string]interface{}, m map[string]interface{}, prefix string, delimiter string) map[string]interface{} {
+	if shadow != nil && prefix != "" && shadow[prefix] != nil {
+		// prefix is shadowed => nothing more to flatten
+		return shadow
+	}
+	if shadow == nil {
+		shadow = make(map[string]interface{})
+	}
+
+	var m2 map[string]interface{}
+	if prefix != "" {
+		prefix += delimiter
+	}
+	for k, val := range m {
+		fullKey := prefix + k
+		switch val.(type) {
+		case map[string]interface{}:
+			m2 = val.(map[string]interface{})
+		case map[interface{}]interface{}:
+			m2 = cast.ToStringMap(val)
+		default:
+			// immediate value
+			shadow[strings.ToLower(fullKey)] = val
+			continue
+		}
+		// recursively merge to shadow map
+		shadow = flattenAndMergeMap(shadow, m2, fullKey, delimiter)
+	}
+	return shadow
+}

--- a/internal/encoding/javaproperties/codec.go
+++ b/internal/encoding/javaproperties/codec.go
@@ -1,0 +1,77 @@
+package javaproperties
+
+import (
+	"bytes"
+	"sort"
+	"strings"
+
+	"github.com/magiconair/properties"
+	"github.com/spf13/cast"
+)
+
+// Codec implements the encoding.Encoder and encoding.Decoder interfaces for Java properties encoding.
+type Codec struct {
+	KeyDelimiter string
+}
+
+func (c Codec) Encode(v map[string]interface{}) ([]byte, error) {
+	p := properties.NewProperties()
+
+	flattened := map[string]interface{}{}
+
+	flattened = flattenAndMergeMap(flattened, v, "", c.keyDelimiter())
+
+	keys := make([]string, 0, len(flattened))
+
+	for key := range flattened {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		_, _, err := p.Set(key, cast.ToString(flattened[key]))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var buf bytes.Buffer
+
+	_, err := p.WriteComment(&buf, "#", properties.UTF8)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (c Codec) Decode(b []byte, v map[string]interface{}) error {
+	p, err := properties.Load(b, properties.UTF8)
+	if err != nil {
+		return err
+	}
+
+	for _, key := range p.Keys() {
+		// ignore existence check: we know it's there
+		value, _ := p.Get(key)
+
+		// recursively build nested maps
+		path := strings.Split(key, c.keyDelimiter())
+		lastKey := strings.ToLower(path[len(path)-1])
+		deepestMap := deepSearch(v, path[0:len(path)-1])
+
+		// set innermost value
+		deepestMap[lastKey] = value
+	}
+
+	return nil
+}
+
+func (c Codec) keyDelimiter() string {
+	if c.KeyDelimiter == "" {
+		return "."
+	}
+
+	return c.KeyDelimiter
+}

--- a/internal/encoding/javaproperties/codec_test.go
+++ b/internal/encoding/javaproperties/codec_test.go
@@ -1,0 +1,69 @@
+package javaproperties
+
+import (
+	"reflect"
+	"testing"
+)
+
+// original form of the data
+const original = `# key-value pair
+key = value
+map.key = value
+`
+
+// encoded form of the data
+const encoded = `key = value
+map.key = value
+`
+
+// Viper's internal representation
+var data = map[string]interface{}{
+	"key": "value",
+	"map": map[string]interface{}{
+		"key": "value",
+	},
+}
+
+func TestCodec_Encode(t *testing.T) {
+	codec := Codec{}
+
+	b, err := codec.Encode(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if encoded != string(b) {
+		t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", string(b), encoded)
+	}
+}
+
+func TestCodec_Decode(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		codec := Codec{}
+
+		v := map[string]interface{}{}
+
+		err := codec.Decode([]byte(original), v)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(data, v) {
+			t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", v, data)
+		}
+	})
+
+	t.Run("InvalidData", func(t *testing.T) {
+		t.Skip("TODO: needs invalid data example")
+
+		codec := Codec{}
+
+		v := map[string]interface{}{}
+
+		codec.Decode([]byte(``), v)
+
+		if len(v) > 0 {
+			t.Fatalf("expected map to be empty when data is invalid\nactual: %#v", v)
+		}
+	})
+}

--- a/internal/encoding/javaproperties/codec_test.go
+++ b/internal/encoding/javaproperties/codec_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 // original form of the data
-const original = `# key-value pair
+const original = `#key-value pair
 key = value
 map.key = value
 `
@@ -66,4 +66,24 @@ func TestCodec_Decode(t *testing.T) {
 			t.Fatalf("expected map to be empty when data is invalid\nactual: %#v", v)
 		}
 	})
+}
+
+func TestCodec_DecodeEncode(t *testing.T) {
+	codec := Codec{}
+
+	v := map[string]interface{}{}
+
+	err := codec.Decode([]byte(original), v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := codec.Encode(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if original != string(b) {
+		t.Fatalf("encoded value does not match the original\nactual:   %#v\nexpected: %#v", string(b), original)
+	}
 }

--- a/internal/encoding/javaproperties/map_utils.go
+++ b/internal/encoding/javaproperties/map_utils.go
@@ -1,0 +1,74 @@
+package javaproperties
+
+import (
+	"strings"
+
+	"github.com/spf13/cast"
+)
+
+// THIS CODE IS COPIED HERE: IT SHOULD NOT BE MODIFIED
+// AT SOME POINT IT WILL BE MOVED TO A COMMON PLACE
+// deepSearch scans deep maps, following the key indexes listed in the
+// sequence "path".
+// The last value is expected to be another map, and is returned.
+//
+// In case intermediate keys do not exist, or map to a non-map value,
+// a new map is created and inserted, and the search continues from there:
+// the initial map "m" may be modified!
+func deepSearch(m map[string]interface{}, path []string) map[string]interface{} {
+	for _, k := range path {
+		m2, ok := m[k]
+		if !ok {
+			// intermediate key does not exist
+			// => create it and continue from there
+			m3 := make(map[string]interface{})
+			m[k] = m3
+			m = m3
+			continue
+		}
+		m3, ok := m2.(map[string]interface{})
+		if !ok {
+			// intermediate key is a value
+			// => replace with a new map
+			m3 = make(map[string]interface{})
+			m[k] = m3
+		}
+		// continue search from here
+		m = m3
+	}
+	return m
+}
+
+// flattenAndMergeMap recursively flattens the given map into a new map
+// Code is based on the function with the same name in tha main package.
+// TODO: move it to a common place
+func flattenAndMergeMap(shadow map[string]interface{}, m map[string]interface{}, prefix string, delimiter string) map[string]interface{} {
+	if shadow != nil && prefix != "" && shadow[prefix] != nil {
+		// prefix is shadowed => nothing more to flatten
+		return shadow
+	}
+	if shadow == nil {
+		shadow = make(map[string]interface{})
+	}
+
+	var m2 map[string]interface{}
+	if prefix != "" {
+		prefix += delimiter
+	}
+	for k, val := range m {
+		fullKey := prefix + k
+		switch val.(type) {
+		case map[string]interface{}:
+			m2 = val.(map[string]interface{})
+		case map[interface{}]interface{}:
+			m2 = cast.ToStringMap(val)
+		default:
+			// immediate value
+			shadow[strings.ToLower(fullKey)] = val
+			continue
+		}
+		// recursively merge to shadow map
+		shadow = flattenAndMergeMap(shadow, m2, fullKey, delimiter)
+	}
+	return shadow
+}

--- a/internal/encoding/json/codec.go
+++ b/internal/encoding/json/codec.go
@@ -7,7 +7,7 @@ import (
 // Codec implements the encoding.Encoder and encoding.Decoder interfaces for JSON encoding.
 type Codec struct{}
 
-func (Codec) Encode(v interface{}) ([]byte, error) {
+func (Codec) Encode(v map[string]interface{}) ([]byte, error) {
 	// TODO: expose prefix and indent in the Codec as setting?
 	return json.MarshalIndent(v, "", "  ")
 }

--- a/internal/encoding/json/codec.go
+++ b/internal/encoding/json/codec.go
@@ -12,6 +12,6 @@ func (Codec) Encode(v interface{}) ([]byte, error) {
 	return json.MarshalIndent(v, "", "  ")
 }
 
-func (Codec) Decode(b []byte, v interface{}) error {
-	return json.Unmarshal(b, v)
+func (Codec) Decode(b []byte, v map[string]interface{}) error {
+	return json.Unmarshal(b, &v)
 }

--- a/internal/encoding/json/codec_test.go
+++ b/internal/encoding/json/codec_test.go
@@ -1,0 +1,95 @@
+package json
+
+import (
+	"reflect"
+	"testing"
+)
+
+// encoded form of the data
+const encoded = `{
+  "key": "value",
+  "list": [
+    "item1",
+    "item2",
+    "item3"
+  ],
+  "map": {
+    "key": "value"
+  },
+  "nested_map": {
+    "map": {
+      "key": "value",
+      "list": [
+        "item1",
+        "item2",
+        "item3"
+      ]
+    }
+  }
+}`
+
+// Viper's internal representation
+var data = map[string]interface{}{
+	"key": "value",
+	"list": []interface{}{
+		"item1",
+		"item2",
+		"item3",
+	},
+	"map": map[string]interface{}{
+		"key": "value",
+	},
+	"nested_map": map[string]interface{}{
+		"map": map[string]interface{}{
+			"key": "value",
+			"list": []interface{}{
+				"item1",
+				"item2",
+				"item3",
+			},
+		},
+	},
+}
+
+func TestCodec_Encode(t *testing.T) {
+	codec := Codec{}
+
+	b, err := codec.Encode(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if encoded != string(b) {
+		t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", string(b), encoded)
+	}
+}
+
+func TestCodec_Decode(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		codec := Codec{}
+
+		v := map[string]interface{}{}
+
+		err := codec.Decode([]byte(encoded), v)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(data, v) {
+			t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", v, data)
+		}
+	})
+
+	t.Run("InvalidData", func(t *testing.T) {
+		codec := Codec{}
+
+		v := map[string]interface{}{}
+
+		err := codec.Decode([]byte(`invalid data`), v)
+		if err == nil {
+			t.Fatal("expected decoding to fail")
+		}
+
+		t.Logf("decoding failed as expected: %s", err)
+	})
+}

--- a/internal/encoding/toml/codec.go
+++ b/internal/encoding/toml/codec.go
@@ -25,21 +25,16 @@ func (Codec) Encode(v interface{}) ([]byte, error) {
 	return toml.Marshal(v)
 }
 
-func (Codec) Decode(b []byte, v interface{}) error {
+func (Codec) Decode(b []byte, v map[string]interface{}) error {
 	tree, err := toml.LoadBytes(b)
 	if err != nil {
 		return err
 	}
 
-	if m, ok := v.(*map[string]interface{}); ok {
-		vmap := *m
-		tmap := tree.ToMap()
-		for k, v := range tmap {
-			vmap[k] = v
-		}
-
-		return nil
+	tmap := tree.ToMap()
+	for key, value := range tmap {
+		v[key] = value
 	}
 
-	return tree.Unmarshal(v)
+	return nil
 }

--- a/internal/encoding/toml/codec.go
+++ b/internal/encoding/toml/codec.go
@@ -7,22 +7,18 @@ import (
 // Codec implements the encoding.Encoder and encoding.Decoder interfaces for TOML encoding.
 type Codec struct{}
 
-func (Codec) Encode(v interface{}) ([]byte, error) {
-	if m, ok := v.(map[string]interface{}); ok {
-		t, err := toml.TreeFromMap(m)
-		if err != nil {
-			return nil, err
-		}
-
-		s, err := t.ToTomlString()
-		if err != nil {
-			return nil, err
-		}
-
-		return []byte(s), nil
+func (Codec) Encode(v map[string]interface{}) ([]byte, error) {
+	t, err := toml.TreeFromMap(v)
+	if err != nil {
+		return nil, err
 	}
 
-	return toml.Marshal(v)
+	s, err := t.ToTomlString()
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(s), nil
 }
 
 func (Codec) Decode(b []byte, v map[string]interface{}) error {

--- a/internal/encoding/toml/codec_test.go
+++ b/internal/encoding/toml/codec_test.go
@@ -1,0 +1,106 @@
+package toml
+
+import (
+	"reflect"
+	"testing"
+)
+
+// original form of the data
+const original = `# key-value pair
+key = "value"
+list = ["item1", "item2", "item3"]
+
+[map]
+key = "value"
+
+# nested
+# map
+[nested_map]
+[nested_map.map]
+key = "value"
+list = [
+  "item1",
+  "item2",
+  "item3",
+]
+`
+
+// encoded form of the data
+const encoded = `key = "value"
+list = ["item1", "item2", "item3"]
+
+[map]
+  key = "value"
+
+[nested_map]
+
+  [nested_map.map]
+    key = "value"
+    list = ["item1", "item2", "item3"]
+`
+
+// Viper's internal representation
+var data = map[string]interface{}{
+	"key": "value",
+	"list": []interface{}{
+		"item1",
+		"item2",
+		"item3",
+	},
+	"map": map[string]interface{}{
+		"key": "value",
+	},
+	"nested_map": map[string]interface{}{
+		"map": map[string]interface{}{
+			"key": "value",
+			"list": []interface{}{
+				"item1",
+				"item2",
+				"item3",
+			},
+		},
+	},
+}
+
+func TestCodec_Encode(t *testing.T) {
+	codec := Codec{}
+
+	b, err := codec.Encode(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if encoded != string(b) {
+		t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", string(b), encoded)
+	}
+}
+
+func TestCodec_Decode(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		codec := Codec{}
+
+		v := map[string]interface{}{}
+
+		err := codec.Decode([]byte(original), v)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(data, v) {
+			t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", v, data)
+		}
+	})
+
+	t.Run("InvalidData", func(t *testing.T) {
+		codec := Codec{}
+
+		v := map[string]interface{}{}
+
+		err := codec.Decode([]byte(`invalid data`), v)
+		if err == nil {
+			t.Fatal("expected decoding to fail")
+		}
+
+		t.Logf("decoding failed as expected: %s", err)
+	})
+}

--- a/internal/encoding/yaml/codec.go
+++ b/internal/encoding/yaml/codec.go
@@ -9,6 +9,6 @@ func (Codec) Encode(v interface{}) ([]byte, error) {
 	return yaml.Marshal(v)
 }
 
-func (Codec) Decode(b []byte, v interface{}) error {
-	return yaml.Unmarshal(b, v)
+func (Codec) Decode(b []byte, v map[string]interface{}) error {
+	return yaml.Unmarshal(b, &v)
 }

--- a/internal/encoding/yaml/codec.go
+++ b/internal/encoding/yaml/codec.go
@@ -5,7 +5,7 @@ import "gopkg.in/yaml.v2"
 // Codec implements the encoding.Encoder and encoding.Decoder interfaces for YAML encoding.
 type Codec struct{}
 
-func (Codec) Encode(v interface{}) ([]byte, error) {
+func (Codec) Encode(v map[string]interface{}) ([]byte, error) {
 	return yaml.Marshal(v)
 }
 

--- a/internal/encoding/yaml/codec_test.go
+++ b/internal/encoding/yaml/codec_test.go
@@ -1,0 +1,136 @@
+package yaml
+
+import (
+	"reflect"
+	"testing"
+)
+
+// original form of the data
+const original = `# key-value pair
+key: value
+list:
+- item1
+- item2
+- item3
+map:
+  key: value
+
+# nested
+# map
+nested_map:
+  map:
+    key: value
+    list:
+    - item1
+    - item2
+    - item3
+`
+
+// encoded form of the data
+const encoded = `key: value
+list:
+- item1
+- item2
+- item3
+map:
+  key: value
+nested_map:
+  map:
+    key: value
+    list:
+    - item1
+    - item2
+    - item3
+`
+
+// decoded form of the data
+//
+// in case of YAML it's slightly different from Viper's internal representation
+// (eg. map is decoded into a map with interface key)
+var decoded = map[string]interface{}{
+	"key": "value",
+	"list": []interface{}{
+		"item1",
+		"item2",
+		"item3",
+	},
+	"map": map[interface{}]interface{}{
+		"key": "value",
+	},
+	"nested_map": map[interface{}]interface{}{
+		"map": map[interface{}]interface{}{
+			"key": "value",
+			"list": []interface{}{
+				"item1",
+				"item2",
+				"item3",
+			},
+		},
+	},
+}
+
+// Viper's internal representation
+var data = map[string]interface{}{
+	"key": "value",
+	"list": []interface{}{
+		"item1",
+		"item2",
+		"item3",
+	},
+	"map": map[string]interface{}{
+		"key": "value",
+	},
+	"nested_map": map[string]interface{}{
+		"map": map[string]interface{}{
+			"key": "value",
+			"list": []interface{}{
+				"item1",
+				"item2",
+				"item3",
+			},
+		},
+	},
+}
+
+func TestCodec_Encode(t *testing.T) {
+	codec := Codec{}
+
+	b, err := codec.Encode(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if encoded != string(b) {
+		t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", string(b), encoded)
+	}
+}
+
+func TestCodec_Decode(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		codec := Codec{}
+
+		v := map[string]interface{}{}
+
+		err := codec.Decode([]byte(original), v)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(decoded, v) {
+			t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", v, decoded)
+		}
+	})
+
+	t.Run("InvalidData", func(t *testing.T) {
+		codec := Codec{}
+
+		v := map[string]interface{}{}
+
+		err := codec.Decode([]byte(`invalid data`), v)
+		if err == nil {
+			t.Fatal("expected decoding to fail")
+		}
+
+		t.Logf("decoding failed as expected: %s", err)
+	})
+}

--- a/viper.go
+++ b/viper.go
@@ -1635,7 +1635,7 @@ func (v *Viper) unmarshalReader(in io.Reader, c map[string]interface{}) error {
 
 	switch format := strings.ToLower(v.getConfigType()); format {
 	case "yaml", "yml", "json", "toml", "hcl", "tfvars":
-		err := decoderRegistry.Decode(format, buf.Bytes(), &c)
+		err := decoderRegistry.Decode(format, buf.Bytes(), c)
 		if err != nil {
 			return ConfigParseError{err}
 		}

--- a/viper.go
+++ b/viper.go
@@ -41,10 +41,10 @@ import (
 	"github.com/spf13/cast"
 	"github.com/spf13/pflag"
 	"github.com/subosito/gotenv"
-	"gopkg.in/ini.v1"
 
 	"github.com/spf13/viper/internal/encoding"
 	"github.com/spf13/viper/internal/encoding/hcl"
+	"github.com/spf13/viper/internal/encoding/ini"
 	"github.com/spf13/viper/internal/encoding/json"
 	"github.com/spf13/viper/internal/encoding/toml"
 	"github.com/spf13/viper/internal/encoding/yaml"
@@ -344,6 +344,16 @@ func (v *Viper) resetEncoding() {
 
 		encoderRegistry.RegisterEncoder("tfvars", codec)
 		decoderRegistry.RegisterDecoder("tfvars", codec)
+	}
+
+	{
+		codec := ini.Codec{
+			KeyDelimiter: v.keyDelim,
+			LoadOptions:  v.iniLoadOptions,
+		}
+
+		encoderRegistry.RegisterEncoder("ini", codec)
+		decoderRegistry.RegisterDecoder("ini", codec)
 	}
 
 	v.encoderRegistry = encoderRegistry
@@ -1646,7 +1656,7 @@ func (v *Viper) unmarshalReader(in io.Reader, c map[string]interface{}) error {
 	buf.ReadFrom(in)
 
 	switch format := strings.ToLower(v.getConfigType()); format {
-	case "yaml", "yml", "json", "toml", "hcl", "tfvars":
+	case "yaml", "yml", "json", "toml", "hcl", "tfvars", "ini":
 		err := v.decoderRegistry.Decode(format, buf.Bytes(), c)
 		if err != nil {
 			return ConfigParseError{err}
@@ -1676,23 +1686,6 @@ func (v *Viper) unmarshalReader(in io.Reader, c map[string]interface{}) error {
 			// set innermost value
 			deepestMap[lastKey] = value
 		}
-
-	case "ini":
-		cfg := ini.Empty(v.iniLoadOptions)
-		err := cfg.Append(buf.Bytes())
-		if err != nil {
-			return ConfigParseError{err}
-		}
-		sections := cfg.Sections()
-		for i := 0; i < len(sections); i++ {
-			section := sections[i]
-			keys := section.Keys()
-			for j := 0; j < len(keys); j++ {
-				key := keys[j]
-				value := cfg.Section(section.Name()).Key(key.Name()).String()
-				c[section.Name()+"."+key.Name()] = value
-			}
-		}
 	}
 
 	insensitiviseMap(c)
@@ -1703,7 +1696,7 @@ func (v *Viper) unmarshalReader(in io.Reader, c map[string]interface{}) error {
 func (v *Viper) marshalWriter(f afero.File, configType string) error {
 	c := v.AllSettings()
 	switch configType {
-	case "yaml", "yml", "json", "toml", "hcl", "tfvars":
+	case "yaml", "yml", "json", "toml", "hcl", "tfvars", "ini":
 		b, err := v.encoderRegistry.Encode(configType, c)
 		if err != nil {
 			return ConfigMarshalError{err}
@@ -1741,22 +1734,6 @@ func (v *Viper) marshalWriter(f afero.File, configType string) error {
 		if _, err := f.WriteString(s); err != nil {
 			return ConfigMarshalError{err}
 		}
-
-	case "ini":
-		keys := v.AllKeys()
-		cfg := ini.Empty()
-		ini.PrettyFormat = false
-		for i := 0; i < len(keys); i++ {
-			key := keys[i]
-			lastSep := strings.LastIndex(key, ".")
-			sectionName := key[:(lastSep)]
-			keyName := key[(lastSep + 1):]
-			if sectionName == "default" {
-				sectionName = ""
-			}
-			cfg.Section(sectionName).Key(keyName).SetValue(v.GetString(key))
-		}
-		cfg.WriteTo(f)
 	}
 	return nil
 }


### PR DESCRIPTION
This is an attempt to further improve the encoding layer specified in #888 and introduced in #986.

Major changes introduced by this PR:

- Encoder/Decoder interfaces now accept `map[string]interface{}` instead of just `interface{}`. The rationale behind that change is that the encoding library is supposed to be used with Viper (it's not a generic library), so it's okay to make the interface Viper specific.
- Two additional codec implementations:
  - INI
  - Java properties
- Encoder/decoder registries are now instantiated per Viper instance. It's required for some codecs (INI, Java props)

The PR also adds some basic tests to the existing encoder implementations.

A couple notes and concerns regarding this change:

Both INI and Java properties require the key delimiter to do some key mutation magic. It's required because both file formats contain key-value pairs (unlike the more common formats like YAML or JSON where you can have more nested configurations). As a result, the codecs have to be instantiated per Viper instance (since the key delimiter can be changed on instantiation).

In Viper 2 this should be a separate configuration of the codec, not tied to Viper's internal key delimiter config to allow storing keys in different formats.

---

Another problem introduced by the Java properties codec is that it's actually stateful: Viper saves the properties structure so it can write back properties files preserving comments and order. This is problematic, because the interface itself is designed for stateless codec instances.

For Viper 2 I think we should drop this feature, because it makes things a lot more complicated. We can hack things around for Viper 1 (eg. create a codec for Viper 1 specifically or make statefullness optional). I can't think of any viable alternative than dropping this feature for Java props. It's not like the most actively used file format and we want to discourage saving config from Viper anyway.

## To Do

- [x] Make tests more robust based on examples in Viper tests (eg. test more INI features)
- [x] Improve the Java properties codec
- [x] ~~Java properties will probably have to be added back to Viper, since codec registries can be reset. Not sure if it's a problem though.~~ No need to reset codecs (for now).
- [x] Implement a dotenv codec

## Misc

Fixes #923