### PR TITLE
Allow merging configs with different types of leaf values

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1808,7 +1808,7 @@ func mergeMaps(
 			v.logger.Trace("merging maps")
 			tsv, ok := sv.(map[string]interface{})
 			if !ok {
-				jww.ERROR.Printf(
+				v.logger.Error(
 					"Could not cast sv to map[string]interface{}; key=%s, st=%v, tt=%v, sv=%v, tv=%v",
 					sk, svType, tvType, sv, tv)
 				continue

--- a/viper_test.go
+++ b/viper_test.go
@@ -1912,6 +1912,22 @@ hello:
 fu: bar
 `)
 
+var jsonMergeExampleTgt = []byte(`
+{
+	"hello": {
+		"pop": 123456
+	}
+}
+`)
+
+var jsonMergeExampleSrc = []byte(`
+{
+	"hello": {
+		"pop": "pop str"
+	}
+}
+`)
+
 func TestMergeConfig(t *testing.T) {
 	v := New()
 	v.SetConfigType("yml")
@@ -1981,6 +1997,22 @@ func TestMergeConfig(t *testing.T) {
 
 	if fu := v.GetString("fu"); fu != "bar" {
 		t.Fatalf("fu != \"bar\", = %s", fu)
+	}
+}
+
+func TestMergeConfigOverrideType(t *testing.T) {
+	v := New()
+	v.SetConfigType("json")
+	if err := v.ReadConfig(bytes.NewBuffer(jsonMergeExampleTgt)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := v.MergeConfig(bytes.NewBuffer(jsonMergeExampleSrc)); err != nil {
+		t.Fatal(err)
+	}
+
+	if pop := v.GetString("hello.pop"); pop != "pop str" {
+		t.Fatalf("pop != \"pop str\", = %s", pop)
 	}
 }
 

--- a/viper_test.go
+++ b/viper_test.go
@@ -1915,6 +1915,7 @@ fu: bar
 var jsonMergeExampleTgt = []byte(`
 {
 	"hello": {
+		"foo": null,
 		"pop": 123456
 	}
 }
@@ -1923,6 +1924,7 @@ var jsonMergeExampleTgt = []byte(`
 var jsonMergeExampleSrc = []byte(`
 {
 	"hello": {
+		"foo": "foo str",
 		"pop": "pop str"
 	}
 }
@@ -2013,6 +2015,10 @@ func TestMergeConfigOverrideType(t *testing.T) {
 
 	if pop := v.GetString("hello.pop"); pop != "pop str" {
 		t.Fatalf("pop != \"pop str\", = %s", pop)
+	}
+
+	if foo := v.GetString("hello.foo"); foo != "foo str" {
+		t.Fatalf("foo != \"foo str\", = %s", foo)
 	}
 }
 


### PR DESCRIPTION
This fixes the problem that appears when your base config has values with different type than the override, which is valid use case.

Fixes #1142