### PR TITLE
docs: fix error handling for file-not-found

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ You can handle the specific case where no config file is found like this:
 
 ```go
 if err := viper.ReadInConfig(); err != nil {
-	if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+	if errors.Is(err, os.ErrNotExist) {
 		// Config file not found; ignore error if desired
 	} else {
 		// Config file was found but another error was produced


### PR DESCRIPTION
I'm not a go expert, so I'm not sure exactly what the example was supposed to do before my change, but it definitely did not work.

Running on go1.17.2 