### PR TITLE
Address confusing contradiction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ where a configuration file is expected.
 
 ```go
 viper.SetConfigName("config") // name of config file (without extension)
-viper.SetConfigType("yaml") // REQUIRED if the config file has an extension
+viper.SetConfigType("yaml") // REQUIRED
 viper.AddConfigPath("/etc/appname/")   // path to look for the config file in
 viper.AddConfigPath("$HOME/.appname")  // call multiple times to add many search paths
 viper.AddConfigPath(".")               // optionally look for config in the working directory

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ where a configuration file is expected.
 
 ```go
 viper.SetConfigName("config") // name of config file (without extension)
-viper.SetConfigType("yaml") // REQUIRED if the config file does not have the extension in the name
+viper.SetConfigType("yaml") // REQUIRED if the config file has an extension
 viper.AddConfigPath("/etc/appname/")   // path to look for the config file in
 viper.AddConfigPath("$HOME/.appname")  // call multiple times to add many search paths
 viper.AddConfigPath(".")               // optionally look for config in the working directory


### PR DESCRIPTION
I just tested it and ``viper.SetConfigName("config.json")`` will not work. Yet the README both states it will and will not work 2 lines apart. This small PR addresses that.