### PR TITLE
Fix: double binary AND

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -431,7 +431,7 @@ func (v *Viper) WatchConfig() {
 							v.onConfigChange(event)
 						}
 					} else if filepath.Clean(event.Name) == configFile &&
-						event.Op&fsnotify.Remove&fsnotify.Remove != 0 {
+						event.Op&fsnotify.Remove != 0 {
 						eventsWG.Done()
 						return
 					}


### PR DESCRIPTION
no need to double binary AND `fsnotify.Remove`