### PR TITLE
Fix viper_go1_15.go if two files with the same name but different types in the same directory

### DIFF
--- a/viper_go1_15.go
+++ b/viper_go1_15.go
@@ -27,17 +27,18 @@ func (v *Viper) findConfigFile() (string, error) {
 
 func (v *Viper) searchInPath(in string) (filename string) {
 	v.logger.Debug("searching for config in path", "path", in)
+	
+	if v.configType != "" && stringInSlice(v.configType,SupportedExts) {
+		if b, _ := exists(v.fs, filepath.Join(in, v.configName)); b {
+			return filepath.Join(in, v.configName)
+		}
+	}
+	
 	for _, ext := range SupportedExts {
 		v.logger.Debug("checking if file exists", "file", filepath.Join(in, v.configName+"."+ext))
 		if b, _ := exists(v.fs, filepath.Join(in, v.configName+"."+ext)); b {
 			v.logger.Debug("found file", "file", filepath.Join(in, v.configName+"."+ext))
 			return filepath.Join(in, v.configName+"."+ext)
-		}
-	}
-
-	if v.configType != "" {
-		if b, _ := exists(v.fs, filepath.Join(in, v.configName)); b {
-			return filepath.Join(in, v.configName)
 		}
 	}
 


### PR DESCRIPTION
If i have two config files in the same path, one's type is yaml and another is toml. But i set the type: `viper.SetConfigType("yaml")`, old viper_go1_15.go will return me the toml's config. Now the bug is fixed.