### PR TITLE
Preventing properties to override each other with Java properties

### DIFF
--- a/internal/encoding/javaproperties/codec.go
+++ b/internal/encoding/javaproperties/codec.go
@@ -2,11 +2,9 @@ package javaproperties
 
 import (
 	"bytes"
-	"sort"
-	"strings"
-
 	"github.com/magiconair/properties"
 	"github.com/spf13/cast"
+	"sort"
 )
 
 // Codec implements the encoding.Encoder and encoding.Decoder interfaces for Java properties encoding.
@@ -64,14 +62,7 @@ func (c *Codec) Decode(b []byte, v map[string]interface{}) error {
 	for _, key := range c.Properties.Keys() {
 		// ignore existence check: we know it's there
 		value, _ := c.Properties.Get(key)
-
-		// recursively build nested maps
-		path := strings.Split(key, c.keyDelimiter())
-		lastKey := strings.ToLower(path[len(path)-1])
-		deepestMap := deepSearch(v, path[0:len(path)-1])
-
-		// set innermost value
-		deepestMap[lastKey] = value
+		v[key] = value
 	}
 
 	return nil

--- a/internal/encoding/javaproperties/codec_test.go
+++ b/internal/encoding/javaproperties/codec_test.go
@@ -18,10 +18,8 @@ map.key = value
 
 // Viper's internal representation
 var data = map[string]interface{}{
-	"key": "value",
-	"map": map[string]interface{}{
-		"key": "value",
-	},
+	"key":     "value",
+	"map.key": "value",
 }
 
 func TestCodec_Encode(t *testing.T) {

--- a/internal/encoding/javaproperties/map_utils.go
+++ b/internal/encoding/javaproperties/map_utils.go
@@ -60,6 +60,8 @@ func flattenAndMergeMap(shadow map[string]interface{}, m map[string]interface{},
 		switch val.(type) {
 		case map[string]interface{}:
 			m2 = val.(map[string]interface{})
+		case []interface{}:
+			m2 = cast.ToStringMap(val)
 		case map[interface{}]interface{}:
 			m2 = cast.ToStringMap(val)
 		default:

--- a/util.go
+++ b/util.go
@@ -190,12 +190,13 @@ func deepSearch(m map[string]interface{}, path []string) map[string]interface{} 
 			m = m3
 			continue
 		}
-		m3, ok := m2.(map[string]interface{})
-		if !ok {
-			// intermediate key is a value
-			// => replace with a new map
+		m3, isMap := m2.(map[string]interface{})
+		if !isMap {
+			// in case the intermediate value is not a map
+			// a slice with previous value and a new map gets created
 			m3 = make(map[string]interface{})
-			m[k] = m3
+			mixedValue := []interface{}{m2, m3}
+			m[k] = mixedValue
 		}
 		// continue search from here
 		m = m3

--- a/viper_test.go
+++ b/viper_test.go
@@ -111,6 +111,7 @@ p_type: donut
 p_name: Cake
 p_ppu: 0.55
 p_batters.batter.type: Regular
+p_batters.batter: Foo
 `)
 
 var remoteExample = []byte(`{
@@ -570,6 +571,8 @@ func TestJSON(t *testing.T) {
 func TestProperties(t *testing.T) {
 	initProperties()
 	assert.Equal(t, "0001", Get("p_id"))
+	assert.Equal(t, "Regular", Get("p_batters.batter.type"))
+	assert.Equal(t, "Foo", Get("p_batters.batter"))
 }
 
 func TestTOML(t *testing.T) {
@@ -765,6 +768,7 @@ func TestAllKeys(t *testing.T) {
 		"p_id",
 		"p_ppu",
 		"p_batters.batter.type",
+		"p_batters.batter",
 		"p_type",
 		"p_name",
 		"foos",
@@ -822,7 +826,10 @@ func TestAllKeys(t *testing.T) {
 		"p_ppu":  "0.55",
 		"p_name": "Cake",
 		"p_batters": map[string]interface{}{
-			"batter": map[string]interface{}{"type": "Regular"},
+			"batter": []interface{}{
+				"Foo",
+				map[string]interface{}{"type": "Regular"},
+			},
 		},
 		"p_type": "donut",
 		"foos": []map[string]interface{}{
@@ -1556,6 +1563,7 @@ p_type = donut
 p_name = Cake
 p_ppu = 0.55
 p_batters.batter.type = Regular
+p_batters.batter = Foo
 `)
 
 // var yamlWriteExpected = []byte(`age: 35


### PR DESCRIPTION
Using Viper in one of our team projects, I noticed that Java properties config has issues at loading a configuration like the following one:
```
app.env=development
app.consumerbroker=first.example.com:9092
app.producerbroker=second.example.com:9092
app.producerbroker.foo=foo
```
Viper returns only:
```
app.env : development
app.producerbroker :
app.producerbroker.foo : foo
app.consumerbroker : first.example.com:9092
```
This PR is meant to solve that.

Let me know what you think about it.

I found open issues related to this topic:
https://github.com/spf13/viper/issues/944
https://github.com/spf13/viper/issues/640