### PR TITLE
Add WatchConfigWithError and remove the log.Fatal in WatchConfig

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -428,19 +428,30 @@ func (v *Viper) OnConfigChange(run func(in fsnotify.Event)) {
 
 func WatchConfig() { v.WatchConfig() }
 
+func (v *Viper) WatchConfigWithError() <-chan error{
+	return v.watchConfig()
+}
+
 func (v *Viper) WatchConfig() {
+	v.watchConfig()
+}
+
+func (v *Viper) watchConfig() <-chan error {
 	initWG := sync.WaitGroup{}
 	initWG.Add(1)
+	errChan := make(chan error, 1)
 	go func() {
 		watcher, err := newWatcher()
 		if err != nil {
-			log.Fatal(err)
+			errChan <- err
+			initWG.Done()
+			return
 		}
 		defer watcher.Close()
 		// we have to watch the entire directory to pick up renames/atomic saves in a cross-platform way
 		filename, err := v.getConfigFile()
 		if err != nil {
-			log.Printf("error: %v\n", err)
+			errChan <- err
 			initWG.Done()
 			return
 		}
@@ -483,7 +494,7 @@ func (v *Viper) WatchConfig() {
 
 				case err, ok := <-watcher.Errors:
 					if ok { // 'Errors' channel is not closed
-						log.Printf("watcher error: %v\n", err)
+						errChan <- err
 					}
 					eventsWG.Done()
 					return
@@ -495,6 +506,7 @@ func (v *Viper) WatchConfig() {
 		eventsWG.Wait() // now, wait for event loop to end in this go-routine...
 	}()
 	initWG.Wait() // make sure that the go routine above fully ended before returning
+	return errChan
 }
 
 // SetConfigFile explicitly defines the path, name and extension of the config file.

--- a/viper_test.go
+++ b/viper_test.go
@@ -2369,6 +2369,19 @@ func newViperWithSymlinkedConfigFile(t *testing.T) (*Viper, string, string, func
 	return v, watchDir, configFile, cleanup
 }
 
+func TestWatchFileWithError(t *testing.T) {
+	t.Run("config file not found", func(t *testing.T) {
+		errChan := v.WatchConfigWithError()
+		err := <-errChan
+		require.Error(t, err)
+	})
+
+	//TODO: newWatcher error
+	t.Run("newWatcher an error occurred", func(t *testing.T) {
+		
+	})
+}
+
 func TestWatchFile(t *testing.T) {
 	if runtime.GOOS == "linux" {
 		// TODO(bep) FIX ME


### PR DESCRIPTION
log.Fatal will make this process exit, which is not good. I think the better way is to return the error to the program using the viper package, and it is up to the caller to decide how to handle this error.

Thank!