### PR TITLE
chore: fix Error log calls in mergeMaps

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1798,8 +1798,13 @@ func mergeMaps(
 			tsv, ok := sv.(map[interface{}]interface{})
 			if !ok {
 				v.logger.Error(
-					"Could not cast sv to map[interface{}]interface{}; key=%s, st=%v, tt=%v, sv=%v, tv=%v",
-					sk, svType, tvType, sv, tv)
+					"Could not cast sv to map[interface{}]interface{}",
+					"key", sk,
+					"st", svType,
+					"tt", tvType,
+					"sv", sv,
+					"tv", tv,
+				)
 				continue
 			}
 
@@ -1811,8 +1816,13 @@ func mergeMaps(
 			tsv, ok := sv.(map[string]interface{})
 			if !ok {
 				v.logger.Error(
-					"Could not cast sv to map[string]interface{}; key=%s, st=%v, tt=%v, sv=%v, tv=%v",
-					sk, svType, tvType, sv, tv)
+					"Could not cast sv to map[string]interface{}",
+					"key", sk,
+					"st", svType,
+					"tt", tvType,
+					"sv", sv,
+					"tv", tv,
+				)
 				continue
 			}
 			mergeMaps(tsv, ttv, nil)


### PR DESCRIPTION
The logger interface uses k,v pairs, but it was being called with a
format string, here.

Changed to use k,v pairs.

I didn't find any other instances of this problem.