### PR TITLE
Make TOML 2 the default

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         go: ['1.15', '1.16', '1.17', '1.18']
-        tags: ['', 'viper_yaml2', 'viper_toml2']
+        tags: ['', 'viper_yaml2', 'viper_toml1']
     env:
       GOFLAGS: -mod=readonly
 

--- a/internal/encoding/toml/codec.go
+++ b/internal/encoding/toml/codec.go
@@ -1,5 +1,5 @@
-//go:build !viper_toml2
-// +build !viper_toml2
+//go:build viper_toml1
+// +build viper_toml1
 
 package toml
 

--- a/internal/encoding/toml/codec2.go
+++ b/internal/encoding/toml/codec2.go
@@ -1,5 +1,5 @@
-//go:build viper_toml2
-// +build viper_toml2
+//go:build !viper_toml1
+// +build !viper_toml1
 
 package toml
 

--- a/internal/encoding/toml/codec2_test.go
+++ b/internal/encoding/toml/codec2_test.go
@@ -1,5 +1,5 @@
-//go:build viper_toml2
-// +build viper_toml2
+//go:build !viper_toml1
+// +build !viper_toml1
 
 package toml
 

--- a/internal/encoding/toml/codec_test.go
+++ b/internal/encoding/toml/codec_test.go
@@ -1,5 +1,5 @@
-//go:build !viper_toml2
-// +build !viper_toml2
+//go:build viper_toml1
+// +build viper_toml1
 
 package toml
 


### PR DESCRIPTION
With this change TOML 3 library will become the default. The old version can be used by adding viper_toml1 to the list of build tags.