### PR TITLE
Use jsonc in markdown codeblocks for better readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,7 +594,7 @@ configuration level.
 
 Viper can access array indices by using numbers in the path. For example:
 
-```json
+```jsonc
 {
     "host": {
         "address": "localhost",
@@ -622,7 +622,7 @@ GetInt("host.ports.1") // returns 6029
 Lastly, if there exists a key that matches the delimited key path, its value
 will be returned instead. E.g.
 
-```json
+```jsonc
 {
     "datastore.metric.host": "0.0.0.0",
     "host": {


### PR DESCRIPTION
## AS-IS

<img width="365" alt="스크린샷 2022-06-28 오전 1 11 56" src="https://user-images.githubusercontent.com/8033896/175986955-474630c4-52d2-473c-a1c1-1799809b0e50.png">

## TO-BE

<img width="340" alt="스크린샷 2022-06-28 오전 1 15 42" src="https://user-images.githubusercontent.com/8033896/175987592-bf9fdb39-c290-4583-b9b5-ef3f0db0f4f9.png">


use `jsonc` instead of `json` to improve readability