### PR TITLE
fix: capitalize the second param in BindEnv

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1286,7 +1286,7 @@ func (v *Viper) find(lcaseKey string, flagDefault bool) interface{} {
 	envkeys, exists := v.env[lcaseKey]
 	if exists {
 		for _, envkey := range envkeys {
-			if val, ok := v.getEnv(envkey); ok {
+			if val, ok := v.getEnv(strings.ToUpper(envkey)); ok {
 				return val
 			}
 		}


### PR DESCRIPTION
## Description
I found an issue in BindEnv. README says as below

>When you explicitly provide the ENV variable name (the second parameter), it does not automatically add the prefix. For example if the second parameter is "id", Viper will look for the ENV variable "ID".

But when passing `id` as the second parameter, viper looks for `id`, not `ID`.

## Example

```
viper.BindEnv("myid", "id")

os.Setenv("ID", "13")
fmt.Println(viper.GetInt("myid")) // 0

os.Setenv("id", "13")
fmt.Println(viper.GetInt("myid")) // 13
```

https://go.dev/play/p/p4SJM03ZNTG

The first parameter in `BindEnv()` is capitalized.
https://github.com/spf13/viper/blob/da55858fffe6093e995244bfc0aa2d9fba370e30/viper.go#L1192

`AutomaticEnv()` also capitalizes names.
https://github.com/spf13/viper/blob/da55858fffe6093e995244bfc0aa2d9fba370e30/viper.go#L1279-L1278

Only the second and subsequent arguments in `BindEnv()` are not capitalized even though the document says `viper will look for the ENV variable "ID"`.