### PR TITLE
Fix config file search for full name with empty config type in viper_go1_15.go

### DIFF
--- a/viper_go1_15.go
+++ b/viper_go1_15.go
@@ -35,7 +35,7 @@ func (v *Viper) searchInPath(in string) (filename string) {
 		}
 	}
 
-	if v.configType != "" {
+	if v.configType == "" {
 		if b, _ := exists(v.fs, filepath.Join(in, v.configName)); b {
 			return filepath.Join(in, v.configName)
 		}


### PR DESCRIPTION
When config type is unset and filename provided with extension, viper fails to properly find that file. 
According to the docs, providing config type when having full file name set is not required.

```
viper.SetConfigName("config") // name of config file (without extension)
viper.SetConfigType("yaml") // REQUIRED if the config file does not have the extension in the name
viper.AddConfigPath("/etc/appname/")   // path to look for the config file in
```
having configuration set like below:
```
vp = viper.New()
vp.AddConfigPath("./workdir/)
vp.SetConfigName("app.env")
```

causes viper to look for files `app.env + "." + supportedExtension`, eg. `app.env.env`
and to skip this part where config path and full file name are joined together.

```
if v.configType != "" {
		if b, _ := exists(v.fs, filepath.Join(in, v.configName)); b {
			return filepath.Join(in, v.configName)
		}
	}
```
code above that makes viper to look for file without adding supported extension at the end of config name is skipped because configType was intentionally unset (`configType == ""`). I think it should behave opposite - should be skipped when I intentionally set config type or config was found using built-in supported types. 