### PR TITLE
Adds support for uint16 with `GetUint16`

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -991,6 +991,13 @@ func (v *Viper) GetUint(key string) uint {
 	return cast.ToUint(v.Get(key))
 }
 
+// GetUint16 returns the value associated with the key as an unsigned integer.
+func GetUint16(key string) uint16 { return v.GetUint16(key) }
+
+func (v *Viper) GetUint16(key string) uint16 {
+	return cast.ToUint16(v.Get(key))
+}
+
 // GetUint32 returns the value associated with the key as an unsigned integer.
 func GetUint32(key string) uint32 { return v.GetUint32(key) }
 

--- a/viper_test.go
+++ b/viper_test.go
@@ -1953,6 +1953,10 @@ func TestMergeConfig(t *testing.T) {
 		t.Fatalf("uint pop != 37890, = %d", pop)
 	}
 
+	if pop := v.GetUint16("hello.pop"); pop != uint16(37890) {
+		t.Fatalf("uint pop != 37890, = %d", pop)
+	}
+
 	if pop := v.GetUint32("hello.pop"); pop != 37890 {
 		t.Fatalf("uint32 pop != 37890, = %d", pop)
 	}


### PR DESCRIPTION
We have encountered numerous places where it is convenient to have viper return a `uint16` value, especially in combination with the new `netip` package  that represents a port correctly as `uint16` rather than just an `int`. cobra already supports this, but we need a conversion from the existing `GetUint` method in viper.
