### PR TITLE
Implement viper.BindStruct for automatic unmarshalling from environment variables

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -2098,9 +2098,13 @@ outer:
 func AllSettings() map[string]any { return v.AllSettings() }
 
 func (v *Viper) AllSettings() map[string]any {
+	return v.getSettings(v.AllKeys())
+}
+
+func (v *Viper) getSettings(keys []string) map[string]any {
 	m := map[string]any{}
 	// start from the list of keys, and construct the map one value at a time
-	for _, k := range v.AllKeys() {
+	for _, k := range keys {
 		value := v.Get(k)
 		if value == nil {
 			// should not happen, since AllKeys() returns only keys holding a value,


### PR DESCRIPTION
## Description

The current `viper` implementation does not allow to `viper.Unmarshal` environment variables into structs without binding them first (using `viper.BindEnv`). This behavior results in an "empty" struct (i.e no values filled) if no configuration file is provided with matching keys.

This pull request adds a new `viper.BindStruct` function which takes a struct pointer and binds each (nested) struct field to an environment variable using the struct field's name or the user-specified `mapstructure` tag. The implementation is quite simple, since I could reuse some functions:

```go
func (v *Viper) BindStruct(input interface{}) error {
	envKeysMap := map[string]interface{}{}
	if err := mapstructure.Decode(input, &envKeysMap); err != nil {
		return err
	}

	structKeys := v.flattenAndMergeMap(map[string]bool{}, envKeysMap, "")
	for key, _ := range structKeys {
		if err := v.BindEnv(key); err != nil {
			return err
		}
	}

	return nil
}
```

A simple example could look like this:

```go
type Configuration struct {
    Value int
}

os.Setenv("VALUE", 42)

var config Configuration
viper.BindStruct(&config)
viper.Unmarshal(&config)
```

Please see the [`TestBindStruct`](https://github.com/krakowski/viper/blob/feature/bind-struct/viper_test.go#L930-L1024) unit test for a more complete example.

## Related Issues
  * Fixes #188
  * Fixes #584
  * Fixes #688
  * Fixes #725 
  * Fixes #761
  * Fixes #1012 
  * Fixes #1365 
  * Fixes #1522 
  * Fixes #1545
  * Fixes #1587

##