### PR TITLE
Allow ConfigParseError to unwrap

### DIFF
--- a/util.go
+++ b/util.go
@@ -27,12 +27,12 @@ type ConfigParseError struct {
 }
 
 // Error returns the formatted configuration error.
-func (pe *ConfigParseError) Error() string {
+func (pe ConfigParseError) Error() string {
 	return fmt.Sprintf("While parsing config: %s", pe.err.Error())
 }
 
 // Unwrap returns the wrapped error.
-func (pe *ConfigParseError) Unwrap() error {
+func (pe ConfigParseError) Unwrap() error {
 	return pe.err
 }
 

--- a/util.go
+++ b/util.go
@@ -27,8 +27,13 @@ type ConfigParseError struct {
 }
 
 // Error returns the formatted configuration error.
-func (pe ConfigParseError) Error() string {
+func (pe *ConfigParseError) Error() string {
 	return fmt.Sprintf("While parsing config: %s", pe.err.Error())
+}
+
+// Unwrap returns the wrapped error.
+func (pe *ConfigParseError) Unwrap() error {
+	return pe.err
 }
 
 // toCaseInsensitiveValue checks if the value is a  map;

--- a/viper.go
+++ b/viper.go
@@ -1700,7 +1700,7 @@ func (v *Viper) unmarshalReader(in io.Reader, c map[string]interface{}) error {
 	case "yaml", "yml", "json", "toml", "hcl", "tfvars", "ini", "properties", "props", "prop", "dotenv", "env":
 		err := v.decoderRegistry.Decode(format, buf.Bytes(), c)
 		if err != nil {
-			return ConfigParseError{err}
+			return &ConfigParseError{err}
 		}
 	}
 

--- a/viper.go
+++ b/viper.go
@@ -1700,7 +1700,7 @@ func (v *Viper) unmarshalReader(in io.Reader, c map[string]interface{}) error {
 	case "yaml", "yml", "json", "toml", "hcl", "tfvars", "ini", "properties", "props", "prop", "dotenv", "env":
 		err := v.decoderRegistry.Decode(format, buf.Bytes(), c)
 		if err != nil {
-			return &ConfigParseError{err}
+			return ConfigParseError{err}
 		}
 	}
 

--- a/viper_test.go
+++ b/viper_test.go
@@ -8,6 +8,7 @@ package viper
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"io/ioutil" //nolint:staticcheck
 	"os"
@@ -1482,6 +1483,21 @@ func TestWrongDirsSearchNotFoundForMerge(t *testing.T) {
 	// Even though config did not load and the error might have
 	// been ignored by the client, the default still loads
 	assert.Equal(t, `default`, v.GetString(`key`))
+}
+
+func TestUnwrap(t *testing.T) {
+	yamlInvalid := []byte(`hash: map
+	- foo
+	- bar
+	`)
+
+	SetConfigType("yaml")
+	err := ReadConfig(bytes.NewBuffer(yamlInvalid))
+
+	var cpe ConfigParseError
+	if !errors.As(err, &cpe) {
+		t.Fatalf("not a ConfigParseError")
+	}
 }
 
 func TestSub(t *testing.T) {

--- a/viper_test.go
+++ b/viper_test.go
@@ -1485,17 +1485,14 @@ func TestWrongDirsSearchNotFoundForMerge(t *testing.T) {
 	assert.Equal(t, `default`, v.GetString(`key`))
 }
 
-func TestUnwrap(t *testing.T) {
-	yamlInvalid := []byte(`hash: map
-	- foo
-	- bar
-	`)
+var yamlInvalid = []byte(`hash: map
+- foo
+- bar
+`)
 
+func TestUnwrapParseErrors(t *testing.T) {
 	SetConfigType("yaml")
-	err := ReadConfig(bytes.NewBuffer(yamlInvalid))
-
-	var cpe ConfigParseError
-	if !errors.As(err, &cpe) {
+	if !errors.As(ReadConfig(bytes.NewBuffer(yamlInvalid)), &ConfigParseError{}) {
 		t.Fatalf("not a ConfigParseError")
 	}
 }


### PR DESCRIPTION
Currently, viper errors cannot be unwrapped and hence do not give access to inner errors. Together with e.g. https://github.com/go-yaml/yaml/pull/760 this could be used to get access to the source file position producing the error.