### PR TITLE
fix: unmarshalReader to an empty kvstore, just as ReadConfig.

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1903,8 +1903,13 @@ func (v *Viper) getRemoteConfig(provider RemoteProvider) (map[string]interface{}
 	if err != nil {
 		return nil, err
 	}
-	err = v.unmarshalReader(reader, v.kvstore)
-	return v.kvstore, err
+	kvstore := make(map[string]interface{})
+	err = v.unmarshalReader(reader, kvstore)
+	if err != nil {
+		return nil, err
+	}
+	v.kvstore = kvstore
+	return v.kvstore, nil
 }
 
 // Retrieve the first found remote configuration.
@@ -1920,7 +1925,13 @@ func (v *Viper) watchKeyValueConfigOnChannel() error {
 			for {
 				b := <-rc
 				reader := bytes.NewReader(b.Value)
-				v.unmarshalReader(reader, v.kvstore)
+				kvstore := make(map[string]interface{})
+				err := v.unmarshalReader(reader, kvstore)
+				if err != nil {
+					v.logger.Warn(fmt.Errorf("watch remote config: %w", err).Error())
+					continue
+				}
+				v.kvstore = kvstore
 			}
 		}(respc)
 		return nil
@@ -1952,8 +1963,13 @@ func (v *Viper) watchRemoteConfig(provider RemoteProvider) (map[string]interface
 	if err != nil {
 		return nil, err
 	}
-	err = v.unmarshalReader(reader, v.kvstore)
-	return v.kvstore, err
+	kvstore := make(map[string]interface{})
+	err = v.unmarshalReader(reader, kvstore)
+	if err != nil {
+		return nil, err
+	}
+	v.kvstore = kvstore
+	return v.kvstore, nil
 }
 
 // AllKeys returns all keys holding a value, regardless of where they are set.


### PR DESCRIPTION
 for example, avoid kvstore not changed if read an empty yaml, while kvstore be empty expected.