### PR TITLE
fix the `Restore cache failed` warning of the ci.yaml github actions job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,13 +20,13 @@ jobs:
             goarch: ppc64
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version: '1.20'
-
-      - name: Checkout code
-        uses: actions/checkout@v3
 
       - name: Build
         run: go build .
@@ -48,13 +48,13 @@ jobs:
       GOFLAGS: -mod=readonly
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
-
-      - name: Checkout code
-        uses: actions/checkout@v3
 
       - name: Test
         run: go test -race -v ./...
@@ -71,13 +71,13 @@ jobs:
       GOFLAGS: -mod=readonly
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version: '1.20'
-
-      - name: Checkout code
-        uses: actions/checkout@v3
 
       - name: Lint
         uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
## Description

- `actions/setup-go` provides module-caching feature for dependencies [from v4](https://github.com/actions/setup-go/releases/tag/v4.0.0).
- However, the cache is not working correctly in the current job configuration.
- One of the example job result is https://github.com/spf13/viper/actions/runs/5120214703 with the warning message `Restore cache failed: Dependencies file is not found in /home/runner/work/viper/viper. Supported file pattern: go.sum`. 

## Cause

- [By default, the caching function of `actions/setup-go` depends on the contents of the go.sum file](https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs) included in the checked-out repository.
- This means that `actions/checkout` must be executed before `action/setup-go` is executed.

## Solution

- The order of steps in the job is changed to `actions/checkout` -> `actions/setup-go`.
