### PR TITLE
Provide SetKeyDelim

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1478,11 +1478,11 @@ func (v *Viper) SetEnvKeyReplacer(r *strings.Replacer) {
 	v.envKeyReplacer = r
 }
 
-// SetKeyDelim sets the delimiter used for determining key parts on the viper
+// SetKeyDelimiter sets the delimiter used for determining key parts on the viper
 // object.
-func SetKeyDelim(d string) { v.SetKeyDelim(d) }
+func SetKeyDelimiter(d string) { v.SetKeyDelimiter(d) }
 
-func (v *Viper) SetKeyDelim(d string) {
+func (v *Viper) SetKeyDelimiter(d string) {
 	v.keyDelim = d
 }
 

--- a/viper.go
+++ b/viper.go
@@ -1478,6 +1478,14 @@ func (v *Viper) SetEnvKeyReplacer(r *strings.Replacer) {
 	v.envKeyReplacer = r
 }
 
+// SetKeyDelim sets the delimiter used for determining key parts on the viper
+// object.
+func SetKeyDelim(d string) { v.SetKeyDelim(d) }
+
+func (v *Viper) SetKeyDelim(d string) {
+	v.keyDelim = d
+}
+
 // RegisterAlias creates an alias that provides another accessor for the same key.
 // This enables one to change a name without breaking the application.
 func RegisterAlias(alias string, key string) { v.RegisterAlias(alias, key) }

--- a/viper_test.go
+++ b/viper_test.go
@@ -2629,6 +2629,54 @@ func TestKeyDelimiter(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestSetKeyDelimiter(t *testing.T) {
+	v := New()
+	v.SetKeyDelimiter("::")
+	v.SetConfigType("yaml")
+	r := strings.NewReader(string(yamlExampleWithDot))
+
+	err := v.unmarshalReader(r, v.config)
+	require.NoError(t, err)
+
+	values := map[string]interface{}{
+		"image": map[string]interface{}{
+			"repository": "someImage",
+			"tag":        "1.0.0",
+		},
+		"ingress": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				"traefik.frontend.rule.type":                 "PathPrefix",
+				"traefik.ingress.kubernetes.io/ssl-redirect": "true",
+			},
+		},
+	}
+
+	v.SetDefault("charts::values", values)
+
+	assert.Equal(t, "leather", v.GetString("clothing::jacket"))
+	assert.Equal(t, "01/02/03", v.GetString("emails::steve@hacker.com::created"))
+
+	type config struct {
+		Charts struct {
+			Values map[string]interface{}
+		}
+	}
+
+	expected := config{
+		Charts: struct {
+			Values map[string]interface{}
+		}{
+			Values: values,
+		},
+	}
+
+	var actual config
+
+	assert.NoError(t, v.Unmarshal(&actual))
+
+	assert.Equal(t, expected, actual)
+}
+
 var yamlDeepNestedSlices = []byte(`TV:
 - title: "The Expanse"
   title_i18n:


### PR DESCRIPTION
Allow the key delimiter to be set on viper objects.

Currently it's not possible to change the key delimiter of viper objects after construction - allow a method to update viper objects after construction similar to `SetEnvKeyReplacer`.