### PR TITLE
fix isPathShadowedInFlatMap type cast bug

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -827,9 +827,11 @@ func (v *Viper) isPathShadowedInDeepMap(path []string, m map[string]interface{})
 func (v *Viper) isPathShadowedInFlatMap(path []string, mi interface{}) string {
 	// unify input map
 	var m map[string]interface{}
-	switch mi.(type) {
-	case map[string]string, map[string]FlagValue:
-		m = cast.ToStringMap(mi)
+	switch miv := mi.(type) {
+	case map[string]string:
+		m = castMapStringToMapInterface(miv)
+	case map[string]FlagValue:
+		m = castMapFlagToMapInterface(miv)
 	default:
 		return ""
 	}

--- a/viper_test.go
+++ b/viper_test.go
@@ -2679,6 +2679,31 @@ func TestSliceIndexAccess(t *testing.T) {
 	assert.Equal(t, "Static", v.GetString("tv.0.episodes.1.2"))
 }
 
+func TestIsPathShadowedInFlatMap(t *testing.T) {
+	v := New()
+
+	stringMap := map[string]string{
+		"foo": "value",
+	}
+
+	flagMap := map[string]FlagValue{
+		"foo": pflagValue{},
+	}
+
+	path1 := []string{"foo", "bar"}
+	expected1 := "foo"
+
+	// "foo.bar" should shadowed by"foo"
+	assert.Equal(t, expected1, v.isPathShadowedInFlatMap(path1, stringMap))
+	assert.Equal(t, expected1, v.isPathShadowedInFlatMap(path1, flagMap))
+
+	path2 := []string{"bar", "foo"}
+	expected2 := ""
+	// "bar.foo" should not shadowed by "foo"
+	assert.Equal(t, expected2, v.isPathShadowedInFlatMap(path2, stringMap))
+	assert.Equal(t, expected2, v.isPathShadowedInFlatMap(path2, flagMap))
+}
+
 func BenchmarkGetBool(b *testing.B) {
 	key := "BenchmarkGetBool"
 	v = New()


### PR DESCRIPTION
The `cast.ToStringMap()` method calls `ToStringMapE()` for type conversion, but `ToStringMapE()` does not support conversion from `map[string]string` and `map[string]FlagValue` to `map[string]interface{}`, so when calling the `isPathShadowedInFlatMap()` method, ToStringMapE will always return a " unable to cast %#v of type %T to `map[string]interface{}`" error, so the `isPathShadowedInFlatMap()` method does nothing. 

So in the `isPathShadowedInFlatMap` method, should to call `castMapStringToMapInterface` and `castMapFlagToMapInterface()` respectively to convert `map[string]string` and `map[string]FlagValue` into `map[string]interface{}`.