### PR TITLE
remove parents to use env prefix instead to avoid mixing both concepts

### DIFF
--- a/viper_test.go
+++ b/viper_test.go
@@ -1604,12 +1604,10 @@ func TestSub(t *testing.T) {
 	assert.Equal(t, (*Viper)(nil), subv)
 
 	subv = v.Sub("clothing")
-	assert.Equal(t, subv.parents[0], "clothing")
+	assert.Equal(t, subv.envPrefix, "CLOTHING")
 
 	subv = v.Sub("clothing").Sub("pants")
-	assert.Equal(t, len(subv.parents), 2)
-	assert.Equal(t, subv.parents[0], "clothing")
-	assert.Equal(t, subv.parents[1], "pants")
+	assert.Equal(t, subv.envPrefix, "CLOTHING_PANTS")
 }
 
 var hclWriteExpected = []byte(`"foos" = {


### PR DESCRIPTION
In the commit [3f4449054d043e278c83a837648d882823a0a3c7](https://github.com/spf13/viper/commit/3f4449054d043e278c83a837648d882823a0a3c7) the concept of parents was added to keep track of the ancestors but led to some regressions (cf: issue [1566](https://github.com/spf13/viper/issues/1566)).

Instead of adding this new concept, why not using the envPrefix which seems to be made for this purpose? It may change Sub's behavior but makes it more intuitive I believe. And keeps the behavior defined by the TestEnvSubConfig.
