### PR TITLE
chore: remove deprecated build tags

### DIFF
--- a/viper_go1_15.go
+++ b/viper_go1_15.go
@@ -1,5 +1,4 @@
 //go:build !finder
-// +build !finder
 
 package viper
 

--- a/viper_go1_16.go
+++ b/viper_go1_16.go
@@ -1,5 +1,4 @@
 //go:build finder
-// +build finder
 
 package viper
 

--- a/watch.go
+++ b/watch.go
@@ -1,5 +1,4 @@
 //go:build darwin || dragonfly || freebsd || openbsd || linux || netbsd || solaris || windows
-// +build darwin dragonfly freebsd openbsd linux netbsd solaris windows
 
 package viper
 

--- a/watch_unsupported.go
+++ b/watch_unsupported.go
@@ -1,5 +1,4 @@
 //go:build appengine || (!darwin && !dragonfly && !freebsd && !openbsd && !linux && !netbsd && !solaris && !windows)
-// +build appengine !darwin,!dragonfly,!freebsd,!openbsd,!linux,!netbsd,!solaris,!windows
 
 package viper
 


### PR DESCRIPTION
`// +build` is obsolete starting from Go 1.18.

https://pkg.go.dev/cmd/go#hdr-Build_constraints