### PR TITLE
fix(watch remote config cause panic):change

### DIFF
--- a/viper_test.go
+++ b/viper_test.go
@@ -167,7 +167,8 @@ func initConfigs() {
 
 	SetConfigType("json")
 	remote := bytes.NewReader(remoteExample)
-	unmarshalReader(remote, v.kvstore)
+	store := v.kvstore.Load().(map[string]interface{})
+	unmarshalReader(remote, store)
 
 	SetConfigType("ini")
 	r = bytes.NewReader(iniExample)
@@ -604,7 +605,8 @@ func TestRemotePrecedence(t *testing.T) {
 
 	remote := bytes.NewReader(remoteExample)
 	assert.Equal(t, "0001", Get("id"))
-	unmarshalReader(remote, v.kvstore)
+	store := v.kvstore.Load().(map[string]interface{})
+	unmarshalReader(remote, store)
 	assert.Equal(t, "0001", Get("id"))
 	assert.NotEqual(t, "cronut", Get("type"))
 	assert.Equal(t, "remote", Get("newkey"))


### PR DESCRIPTION
if we used watch remote config function，when the configuration changes, I happen to be reading the configuration and panic occurs.

You can use the following code to reproduce the problem.

My idea is to copy on write, replacing the original map with a new one when the configuration changes.


```go

type remoteConfigProvider struct{}

func (rc remoteConfigProvider) Get(rp viper.RemoteProvider) (io.Reader, error) {
	log.Println("Getting config from remote", rp)
	r := bytes.NewReader([]byte("{\"a\":1}"))
	//time.Sleep(time.Second)
	return r, nil
}

func (rc remoteConfigProvider) Watch(rp viper.RemoteProvider) (io.Reader, error) {

	log.Println("Watching config from remote", rp)
	s := fmt.Sprintf(`{"app":{"name":"test","version":%d}}`, time.Now().Unix())
	r := bytes.NewReader([]byte(s))
	//time.Sleep(time.Second)
	return r, nil
}

func (rc remoteConfigProvider) WatchChannel(rp viper.RemoteProvider) (<-chan *viper.RemoteResponse, chan bool) {
	log.Println("Watching  Channel config from remote", rp)
	ch := make(chan *viper.RemoteResponse)
	go func() {
		defer close(ch)

		for i := 0; ; i++ {
			ch <- &viper.RemoteResponse{
				Value: []byte(fmt.Sprintf(`{"app":{"name":"test","version":%d}}`, time.Now().Unix())),
			}
			time.Sleep(time.Second)
		}

	}()
	return ch, nil
}
func init() {
	viper.RemoteConfig = remoteConfigProvider{}
	viper.SupportedRemoteProviders = []string{"app"}
}

func main() {

        viper.SetConfigType("json")
	viper.AddRemoteProvider("app", ":8080", "/aabb/cc")
	viper.ReadRemoteConfig()
	fmt.Println("-----------", viper.GetInt64("b"))
	 viper.WatchRemoteConfig()
	viper.GetViper().WatchRemoteConfigOnChannel()

       for i := 0; i < 10000; i++ {
			fmt.Println(viper.GetInt64("A"), viper.Get("app"), viper.AllKeys())
			// if i%1000 == 0 {
			// 	time.Sleep(time.Second)
			// }
			//time.Sleep(time.Second)
	}
}
``` 