### PR TITLE
ci: enable test shuffle and fix tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,11 +57,11 @@ jobs:
           go-version: ${{ matrix.go }}
 
       - name: Test
-        run: go test -race -v -tags '${{ matrix.tags }}' ./...
+        run: go test -race -v -tags '${{ matrix.tags }}' -shuffle=on ./...
         if: runner.os != 'Windows'
 
       - name: Test (without race detector)
-        run: go test -v -tags '${{ matrix.tags }}' ./...
+        run: go test -v -tags '${{ matrix.tags }}' -shuffle=on ./...
         if: runner.os == 'Windows'
 
   lint:

--- a/flags_test.go
+++ b/flags_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestBindFlagValueSet(t *testing.T) {
+	Reset()
 	flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
 
 	testValues := map[string]*string{

--- a/viper_test.go
+++ b/viper_test.go
@@ -472,6 +472,7 @@ func TestReadInConfig(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
+	Reset()
 	SetDefault("age", 45)
 	assert.Equal(t, 45, Get("age"))
 
@@ -486,6 +487,7 @@ func TestDefault(t *testing.T) {
 }
 
 func TestUnmarshaling(t *testing.T) {
+	Reset()
 	SetConfigType("yaml")
 	r := bytes.NewReader(yamlExample)
 
@@ -524,6 +526,8 @@ func TestDefaultPost(t *testing.T) {
 }
 
 func TestAliases(t *testing.T) {
+	initConfigs()
+	Set("age", 40)
 	RegisterAlias("years", "age")
 	assert.Equal(t, 40, Get("years"))
 	Set("years", 45)
@@ -531,6 +535,7 @@ func TestAliases(t *testing.T) {
 }
 
 func TestAliasInConfigFile(t *testing.T) {
+	initConfigs()
 	// the config file specifies "beard".  If we make this an alias for
 	// "hasbeard", we still want the old config file to work with beard.
 	RegisterAlias("beard", "hasbeard")
@@ -873,6 +878,7 @@ func TestRecursiveAliases(t *testing.T) {
 }
 
 func TestUnmarshal(t *testing.T) {
+	Reset()
 	SetDefault("port", 1313)
 	Set("name", "Steve")
 	Set("duration", "1s1ms")
@@ -1277,6 +1283,7 @@ func TestBindPFlagStringToInt(t *testing.T) {
 }
 
 func TestBoundCaseSensitivity(t *testing.T) {
+	initConfigs()
 	assert.Equal(t, "brown", Get("eyes"))
 
 	BindEnv("eYEs", "TURTLE_EYES")


### PR DESCRIPTION
This PR extends `go test` with `-shuffle` [flag](https://pkg.go.dev/cmd/go#hdr-Testing_flags):
> ```
> -shuffle off,on,N
>     Randomize the execution order of tests and benchmarks.
>     It is off by default. If -shuffle is set to on, then it will seed
>     the randomizer using the system clock. If -shuffle is set to an
>     integer N, then N will be used as the seed value. In both cases,
>     the seed will be reported for reproducibility.
> ```

Also, fix conflicting tests.