### PR TITLE
test: refactor asserts

### DIFF
--- a/flags_test.go
+++ b/flags_test.go
@@ -39,7 +39,7 @@ func TestBindFlagValueSet(t *testing.T) {
 	})
 
 	for name, expected := range mutatedTestValues {
-		assert.Equal(t, Get(name), expected)
+		assert.Equal(t, expected, Get(name))
 	}
 }
 

--- a/overrides_test.go
+++ b/overrides_test.go
@@ -1,7 +1,6 @@
 package viper
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -148,10 +147,9 @@ func deepCheckValue(assert *assert.Assertions, v *Viper, l layer, keys []string,
 
 	// loop through map
 	var m map[string]any
-	err := false
 	for _, k := range keys {
 		if val == nil {
-			assert.Fail(fmt.Sprintf("%s is not a map[string]any", ms))
+			assert.Failf("%s is not a map[string]any", ms)
 			return
 		}
 
@@ -162,13 +160,11 @@ func deepCheckValue(assert *assert.Assertions, v *Viper, l layer, keys []string,
 		case map[string]any:
 			m = val
 		default:
-			assert.Fail(fmt.Sprintf("%s is not a map[string]any", ms))
+			assert.Failf("%s is not a map[string]any", ms)
 			return
 		}
 		ms = ms + "[\"" + k + "\"]"
 		val = m[k]
 	}
-	if !err {
-		assert.Equal(value, val)
-	}
+	assert.Equal(value, val)
 }


### PR DESCRIPTION
This PR refactors tests:

- reverse actual and expected values in some asserts;
- replace `require.Nil(t, err)` with `require.NoError(t, err)`;
- simplifies slice comparison;
- replace `assert.Equal(t, 1, len(items))` with `assert.Len(t, items, 1)`;
- replace sorted slice comparing with `assert.ElementsMatch`;
- use `assert.Failf(...)` instead of `assert.Fail(fmt.Sprintf(...))`;
- use `assert.IsType(...)` instead of `assert.Equal(t, reflect.TypeOf(...)`.