### PR TITLE
test: replace ifs with asserts to simplify tests

### DIFF
--- a/flags_test.go
+++ b/flags_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBindFlagValueSet(t *testing.T) {
@@ -29,9 +30,7 @@ func TestBindFlagValueSet(t *testing.T) {
 	flagValueSet := pflagValueSet{flagSet}
 
 	err := BindFlagValues(flagValueSet)
-	if err != nil {
-		t.Fatalf("error binding flag set, %v", err)
-	}
+	require.NoError(t, err, "error binding flag set")
 
 	flagSet.VisitAll(func(flag *pflag.Flag) {
 		flag.Value.Set(mutatedTestValues[flag.Name])

--- a/internal/encoding/decoder_test.go
+++ b/internal/encoding/decoder_test.go
@@ -1,8 +1,10 @@
 package encoding
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type decoder struct {
@@ -22,23 +24,17 @@ func TestDecoderRegistry_RegisterDecoder(t *testing.T) {
 		registry := NewDecoderRegistry()
 
 		err := registry.RegisterDecoder("myformat", decoder{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	})
 
 	t.Run("AlreadyRegistered", func(t *testing.T) {
 		registry := NewDecoderRegistry()
 
 		err := registry.RegisterDecoder("myformat", decoder{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		err = registry.RegisterDecoder("myformat", decoder{})
-		if err != ErrDecoderFormatAlreadyRegistered {
-			t.Fatalf("expected ErrDecoderFormatAlreadyRegistered, got: %v", err)
-		}
+		assert.ErrorIs(t, err, ErrDecoderFormatAlreadyRegistered)
 	})
 }
 
@@ -52,20 +48,14 @@ func TestDecoderRegistry_Decode(t *testing.T) {
 		}
 
 		err := registry.RegisterDecoder("myformat", decoder)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		v := map[string]any{}
 
 		err = registry.Decode("myformat", []byte("key: value"), v)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if !reflect.DeepEqual(decoder.v, v) {
-			t.Fatalf("decoded value does not match the expected one\nactual:   %+v\nexpected: %+v", v, decoder.v)
-		}
+		assert.Equal(t, decoder.v, v)
 	})
 
 	t.Run("DecoderNotFound", func(t *testing.T) {
@@ -74,8 +64,6 @@ func TestDecoderRegistry_Decode(t *testing.T) {
 		v := map[string]any{}
 
 		err := registry.Decode("myformat", nil, v)
-		if err != ErrDecoderNotFound {
-			t.Fatalf("expected ErrDecoderNotFound, got: %v", err)
-		}
+		assert.ErrorIs(t, err, ErrDecoderNotFound)
 	})
 }

--- a/internal/encoding/dotenv/codec_test.go
+++ b/internal/encoding/dotenv/codec_test.go
@@ -1,8 +1,10 @@
 package dotenv
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // original form of the data
@@ -23,13 +25,9 @@ func TestCodec_Encode(t *testing.T) {
 	codec := Codec{}
 
 	b, err := codec.Encode(data)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if encoded != string(b) {
-		t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", string(b), encoded)
-	}
+	assert.Equal(t, encoded, string(b))
 }
 
 func TestCodec_Decode(t *testing.T) {
@@ -39,13 +37,9 @@ func TestCodec_Decode(t *testing.T) {
 		v := map[string]any{}
 
 		err := codec.Decode([]byte(original), v)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if !reflect.DeepEqual(data, v) {
-			t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", v, data)
-		}
+		assert.Equal(t, data, v)
 	})
 
 	t.Run("InvalidData", func(t *testing.T) {
@@ -54,9 +48,7 @@ func TestCodec_Decode(t *testing.T) {
 		v := map[string]any{}
 
 		err := codec.Decode([]byte(`invalid data`), v)
-		if err == nil {
-			t.Fatal("expected decoding to fail")
-		}
+		require.Error(t, err)
 
 		t.Logf("decoding failed as expected: %s", err)
 	})

--- a/internal/encoding/encoder_test.go
+++ b/internal/encoding/encoder_test.go
@@ -2,6 +2,9 @@ package encoding
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type encoder struct {
@@ -17,23 +20,17 @@ func TestEncoderRegistry_RegisterEncoder(t *testing.T) {
 		registry := NewEncoderRegistry()
 
 		err := registry.RegisterEncoder("myformat", encoder{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	})
 
 	t.Run("AlreadyRegistered", func(t *testing.T) {
 		registry := NewEncoderRegistry()
 
 		err := registry.RegisterEncoder("myformat", encoder{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		err = registry.RegisterEncoder("myformat", encoder{})
-		if err != ErrEncoderFormatAlreadyRegistered {
-			t.Fatalf("expected ErrEncoderFormatAlreadyRegistered, got: %v", err)
-		}
+		assert.ErrorIs(t, err, ErrEncoderFormatAlreadyRegistered)
 	})
 }
 
@@ -45,26 +42,18 @@ func TestEncoderRegistry_Decode(t *testing.T) {
 		}
 
 		err := registry.RegisterEncoder("myformat", encoder)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		b, err := registry.Encode("myformat", map[string]any{"key": "value"})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if string(b) != "key: value" {
-			t.Fatalf("expected 'key: value', got: %#v", string(b))
-		}
+		assert.Equal(t, "key: value", string(b))
 	})
 
 	t.Run("EncoderNotFound", func(t *testing.T) {
 		registry := NewEncoderRegistry()
 
 		_, err := registry.Encode("myformat", map[string]any{"key": "value"})
-		if err != ErrEncoderNotFound {
-			t.Fatalf("expected ErrEncoderNotFound, got: %v", err)
-		}
+		assert.ErrorIs(t, err, ErrEncoderNotFound)
 	})
 }

--- a/internal/encoding/hcl/codec_test.go
+++ b/internal/encoding/hcl/codec_test.go
@@ -1,8 +1,10 @@
 package hcl
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // original form of the data
@@ -100,13 +102,9 @@ func TestCodec_Encode(t *testing.T) {
 	codec := Codec{}
 
 	b, err := codec.Encode(data)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if encoded != string(b) {
-		t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", string(b), encoded)
-	}
+	assert.Equal(t, encoded, string(b))
 }
 
 func TestCodec_Decode(t *testing.T) {
@@ -116,13 +114,9 @@ func TestCodec_Decode(t *testing.T) {
 		v := map[string]any{}
 
 		err := codec.Decode([]byte(original), v)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if !reflect.DeepEqual(decoded, v) {
-			t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", v, decoded)
-		}
+		assert.Equal(t, decoded, v)
 	})
 
 	t.Run("InvalidData", func(t *testing.T) {
@@ -131,9 +125,7 @@ func TestCodec_Decode(t *testing.T) {
 		v := map[string]any{}
 
 		err := codec.Decode([]byte(`invalid data`), v)
-		if err == nil {
-			t.Fatal("expected decoding to fail")
-		}
+		require.Error(t, err)
 
 		t.Logf("decoding failed as expected: %s", err)
 	})

--- a/internal/encoding/ini/codec_test.go
+++ b/internal/encoding/ini/codec_test.go
@@ -1,8 +1,10 @@
 package ini
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // original form of the data
@@ -48,13 +50,9 @@ func TestCodec_Encode(t *testing.T) {
 		codec := Codec{}
 
 		b, err := codec.Encode(data)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if encoded != string(b) {
-			t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", string(b), encoded)
-		}
+		assert.Equal(t, encoded, string(b))
 	})
 
 	t.Run("Default", func(t *testing.T) {
@@ -70,13 +68,9 @@ func TestCodec_Encode(t *testing.T) {
 		}
 
 		b, err := codec.Encode(data)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if encoded != string(b) {
-			t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", string(b), encoded)
-		}
+		assert.Equal(t, encoded, string(b))
 	})
 }
 
@@ -87,13 +81,9 @@ func TestCodec_Decode(t *testing.T) {
 		v := map[string]any{}
 
 		err := codec.Decode([]byte(original), v)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if !reflect.DeepEqual(decoded, v) {
-			t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", v, decoded)
-		}
+		assert.Equal(t, decoded, v)
 	})
 
 	t.Run("InvalidData", func(t *testing.T) {
@@ -102,9 +92,7 @@ func TestCodec_Decode(t *testing.T) {
 		v := map[string]any{}
 
 		err := codec.Decode([]byte(`invalid data`), v)
-		if err == nil {
-			t.Fatal("expected decoding to fail")
-		}
+		require.Error(t, err)
 
 		t.Logf("decoding failed as expected: %s", err)
 	})

--- a/internal/encoding/javaproperties/codec_test.go
+++ b/internal/encoding/javaproperties/codec_test.go
@@ -1,8 +1,10 @@
 package javaproperties
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // original form of the data
@@ -28,13 +30,9 @@ func TestCodec_Encode(t *testing.T) {
 	codec := Codec{}
 
 	b, err := codec.Encode(data)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if encoded != string(b) {
-		t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", string(b), encoded)
-	}
+	assert.Equal(t, encoded, string(b))
 }
 
 func TestCodec_Decode(t *testing.T) {
@@ -44,13 +42,9 @@ func TestCodec_Decode(t *testing.T) {
 		v := map[string]any{}
 
 		err := codec.Decode([]byte(original), v)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if !reflect.DeepEqual(data, v) {
-			t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", v, data)
-		}
+		assert.Equal(t, data, v)
 	})
 
 	t.Run("InvalidData", func(t *testing.T) {
@@ -62,9 +56,7 @@ func TestCodec_Decode(t *testing.T) {
 
 		codec.Decode([]byte(``), v)
 
-		if len(v) > 0 {
-			t.Fatalf("expected map to be empty when data is invalid\nactual: %#v", v)
-		}
+		assert.Empty(t, v)
 	})
 }
 
@@ -74,16 +66,10 @@ func TestCodec_DecodeEncode(t *testing.T) {
 	v := map[string]any{}
 
 	err := codec.Decode([]byte(original), v)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	b, err := codec.Encode(data)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if original != string(b) {
-		t.Fatalf("encoded value does not match the original\nactual:   %#v\nexpected: %#v", string(b), original)
-	}
+	assert.Equal(t, original, string(b))
 }

--- a/internal/encoding/json/codec_test.go
+++ b/internal/encoding/json/codec_test.go
@@ -1,8 +1,10 @@
 package json
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // encoded form of the data
@@ -55,13 +57,9 @@ func TestCodec_Encode(t *testing.T) {
 	codec := Codec{}
 
 	b, err := codec.Encode(data)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if encoded != string(b) {
-		t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", string(b), encoded)
-	}
+	assert.Equal(t, encoded, string(b))
 }
 
 func TestCodec_Decode(t *testing.T) {
@@ -71,13 +69,9 @@ func TestCodec_Decode(t *testing.T) {
 		v := map[string]any{}
 
 		err := codec.Decode([]byte(encoded), v)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if !reflect.DeepEqual(data, v) {
-			t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", v, data)
-		}
+		assert.Equal(t, data, v)
 	})
 
 	t.Run("InvalidData", func(t *testing.T) {
@@ -86,9 +80,7 @@ func TestCodec_Decode(t *testing.T) {
 		v := map[string]any{}
 
 		err := codec.Decode([]byte(`invalid data`), v)
-		if err == nil {
-			t.Fatal("expected decoding to fail")
-		}
+		require.Error(t, err)
 
 		t.Logf("decoding failed as expected: %s", err)
 	})

--- a/internal/encoding/toml/codec_test.go
+++ b/internal/encoding/toml/codec_test.go
@@ -1,8 +1,10 @@
 package toml
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // original form of the data
@@ -65,13 +67,9 @@ func TestCodec_Encode(t *testing.T) {
 	codec := Codec{}
 
 	b, err := codec.Encode(data)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if encoded != string(b) {
-		t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", string(b), encoded)
-	}
+	assert.Equal(t, encoded, string(b))
 }
 
 func TestCodec_Decode(t *testing.T) {
@@ -81,13 +79,9 @@ func TestCodec_Decode(t *testing.T) {
 		v := map[string]any{}
 
 		err := codec.Decode([]byte(original), v)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if !reflect.DeepEqual(data, v) {
-			t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", v, data)
-		}
+		assert.Equal(t, data, v)
 	})
 
 	t.Run("InvalidData", func(t *testing.T) {
@@ -96,9 +90,7 @@ func TestCodec_Decode(t *testing.T) {
 		v := map[string]any{}
 
 		err := codec.Decode([]byte(`invalid data`), v)
-		if err == nil {
-			t.Fatal("expected decoding to fail")
-		}
+		require.Error(t, err)
 
 		t.Logf("decoding failed as expected: %s", err)
 	})

--- a/internal/encoding/yaml/codec_test.go
+++ b/internal/encoding/yaml/codec_test.go
@@ -1,8 +1,10 @@
 package yaml
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // original form of the data
@@ -96,13 +98,9 @@ func TestCodec_Encode(t *testing.T) {
 	codec := Codec{}
 
 	b, err := codec.Encode(data)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if encoded != string(b) {
-		t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", string(b), encoded)
-	}
+	assert.Equal(t, encoded, string(b))
 }
 
 func TestCodec_Decode(t *testing.T) {
@@ -112,13 +110,9 @@ func TestCodec_Decode(t *testing.T) {
 		v := map[string]any{}
 
 		err := codec.Decode([]byte(original), v)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if !reflect.DeepEqual(decoded, v) {
-			t.Fatalf("decoded value does not match the expected one\nactual:   %#v\nexpected: %#v", v, decoded)
-		}
+		assert.Equal(t, decoded, v)
 	})
 
 	t.Run("InvalidData", func(t *testing.T) {
@@ -127,9 +121,7 @@ func TestCodec_Decode(t *testing.T) {
 		v := map[string]any{}
 
 		err := codec.Decode([]byte(`invalid data`), v)
-		if err == nil {
-			t.Fatal("expected decoding to fail")
-		}
+		require.Error(t, err)
 
 		t.Logf("decoding failed as expected: %s", err)
 	})

--- a/util_test.go
+++ b/util_test.go
@@ -13,10 +13,10 @@ package viper
 import (
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 
 	slog "github.com/sagikazarmark/slog-shim"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCopyAndInsensitiviseMap(t *testing.T) {
@@ -39,22 +39,15 @@ func TestCopyAndInsensitiviseMap(t *testing.T) {
 
 	got := copyAndInsensitiviseMap(given)
 
-	if !reflect.DeepEqual(got, expected) {
-		t.Fatalf("Got %q\nexpected\n%q", got, expected)
-	}
-
-	if _, ok := given["foo"]; ok {
-		t.Fatal("Input map changed")
-	}
-
-	if _, ok := given["bar"]; ok {
-		t.Fatal("Input map changed")
-	}
+	assert.Equal(t, expected, got)
+	_, ok := given["foo"]
+	assert.False(t, ok)
+	_, ok = given["bar"]
+	assert.False(t, ok)
 
 	m := given["Bar"].(map[any]any)
-	if _, ok := m["ABc"]; !ok {
-		t.Fatal("Input map changed")
-	}
+	_, ok = m["ABc"]
+	assert.True(t, ok)
 }
 
 func TestAbsPathify(t *testing.T) {
@@ -88,8 +81,6 @@ func TestAbsPathify(t *testing.T) {
 
 	for _, test := range tests {
 		got := absPathify(slog.Default(), test.input)
-		if got != test.output {
-			t.Errorf("Got %v\nexpected\n%q", got, test.output)
-		}
+		assert.Equal(t, test.output, got)
 	}
 }


### PR DESCRIPTION
This PR refactors tests to use functions from the `testify` package instead of `if`s.

As a bonus, we can remove `//nolint:dupl` comments.