### PR TITLE
fix: godot lint issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -22,6 +22,7 @@ linters:
         - exhaustive
         - exportloopref
         - gci
+        - godot
         - gofmt
         - gofumpt
         - goimports
@@ -64,7 +65,6 @@ linters:
         # - goconst
         # - gocritic
         # - gocyclo
-        # - godot
         # - gosec
         # - gosimple
         # - ifshort

--- a/file.go
+++ b/file.go
@@ -43,7 +43,7 @@ func (v *Viper) searchInPath(in string) (filename string) {
 	return ""
 }
 
-// Check if file Exists
+// exists checks if file exists.
 func exists(fs afero.Fs, path string) (bool, error) {
 	stat, err := fs.Stat(path)
 	if err == nil {

--- a/flags.go
+++ b/flags.go
@@ -31,7 +31,7 @@ func (p pflagValueSet) VisitAll(fn func(flag FlagValue)) {
 }
 
 // pflagValue is a wrapper around *pflag.flag
-// that implements FlagValue
+// that implements FlagValue.
 type pflagValue struct {
 	flag *pflag.Flag
 }

--- a/internal/encoding/dotenv/codec_test.go
+++ b/internal/encoding/dotenv/codec_test.go
@@ -5,16 +5,16 @@ import (
 	"testing"
 )
 
-// original form of the data
+// original form of the data.
 const original = `# key-value pair
 KEY=value
 `
 
-// encoded form of the data
+// encoded form of the data.
 const encoded = `KEY=value
 `
 
-// Viper's internal representation
+// data is Viper's internal representation.
 var data = map[string]any{
 	"KEY": "value",
 }

--- a/internal/encoding/dotenv/map_utils.go
+++ b/internal/encoding/dotenv/map_utils.go
@@ -8,7 +8,7 @@ import (
 
 // flattenAndMergeMap recursively flattens the given map into a new map
 // Code is based on the function with the same name in the main package.
-// TODO: move it to a common place
+// TODO: move it to a common place.
 func flattenAndMergeMap(shadow map[string]any, m map[string]any, prefix string, delimiter string) map[string]any {
 	if shadow != nil && prefix != "" && shadow[prefix] != nil {
 		// prefix is shadowed => nothing more to flatten

--- a/internal/encoding/hcl/codec_test.go
+++ b/internal/encoding/hcl/codec_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// original form of the data
+// original form of the data.
 const original = `# key-value pair
 "key" = "value"
 
@@ -26,7 +26,7 @@ nested map
   "list" = ["item1", "item2", "item3"]
 }`
 
-// encoded form of the data
+// encoded form of the data.
 const encoded = `"key" = "value"
 
 "list" = ["item1", "item2", "item3"]
@@ -41,10 +41,10 @@ const encoded = `"key" = "value"
   "list" = ["item1", "item2", "item3"]
 }`
 
-// decoded form of the data
+// decoded form of the data.
 //
-// in case of HCL it's slightly different from Viper's internal representation
-// (eg. map is decoded into a list of maps)
+// In case of HCL it's slightly different from Viper's internal representation
+// (e.g. map is decoded into a list of maps).
 var decoded = map[string]any{
 	"key": "value",
 	"list": []any{
@@ -73,7 +73,7 @@ var decoded = map[string]any{
 	},
 }
 
-// Viper's internal representation
+// data is Viper's internal representation.
 var data = map[string]any{
 	"key": "value",
 	"list": []any{

--- a/internal/encoding/ini/codec_test.go
+++ b/internal/encoding/ini/codec_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// original form of the data
+// original form of the data.
 const original = `; key-value pair
 key=value ; key-value pair
 
@@ -15,17 +15,17 @@ key=%(key)s
 
 `
 
-// encoded form of the data
+// encoded form of the data.
 const encoded = `key=value
 
 [map]
 key=value
 `
 
-// decoded form of the data
+// decoded form of the data.
 //
-// in case of INI it's slightly different from Viper's internal representation
-// (eg. top level keys land in a section called default)
+// In case of INI it's slightly different from Viper's internal representation
+// (e.g. top level keys land in a section called default).
 var decoded = map[string]any{
 	"DEFAULT": map[string]any{
 		"key": "value",
@@ -35,7 +35,7 @@ var decoded = map[string]any{
 	},
 }
 
-// Viper's internal representation
+// data is Viper's internal representation.
 var data = map[string]any{
 	"key": "value",
 	"map": map[string]any{

--- a/internal/encoding/ini/map_utils.go
+++ b/internal/encoding/ini/map_utils.go
@@ -41,7 +41,7 @@ func deepSearch(m map[string]any, path []string) map[string]any {
 
 // flattenAndMergeMap recursively flattens the given map into a new map
 // Code is based on the function with the same name in the main package.
-// TODO: move it to a common place
+// TODO: move it to a common place.
 func flattenAndMergeMap(shadow map[string]any, m map[string]any, prefix string, delimiter string) map[string]any {
 	if shadow != nil && prefix != "" && shadow[prefix] != nil {
 		// prefix is shadowed => nothing more to flatten

--- a/internal/encoding/javaproperties/codec_test.go
+++ b/internal/encoding/javaproperties/codec_test.go
@@ -5,18 +5,18 @@ import (
 	"testing"
 )
 
-// original form of the data
+// original form of the data.
 const original = `#key-value pair
 key = value
 map.key = value
 `
 
-// encoded form of the data
+// encoded form of the data.
 const encoded = `key = value
 map.key = value
 `
 
-// Viper's internal representation
+// data is Viper's internal representation.
 var data = map[string]any{
 	"key": "value",
 	"map": map[string]any{

--- a/internal/encoding/javaproperties/map_utils.go
+++ b/internal/encoding/javaproperties/map_utils.go
@@ -41,7 +41,7 @@ func deepSearch(m map[string]any, path []string) map[string]any {
 
 // flattenAndMergeMap recursively flattens the given map into a new map
 // Code is based on the function with the same name in the main package.
-// TODO: move it to a common place
+// TODO: move it to a common place.
 func flattenAndMergeMap(shadow map[string]any, m map[string]any, prefix string, delimiter string) map[string]any {
 	if shadow != nil && prefix != "" && shadow[prefix] != nil {
 		// prefix is shadowed => nothing more to flatten

--- a/internal/encoding/json/codec_test.go
+++ b/internal/encoding/json/codec_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// encoded form of the data
+// encoded form of the data.
 const encoded = `{
   "key": "value",
   "list": [
@@ -28,7 +28,7 @@ const encoded = `{
   }
 }`
 
-// Viper's internal representation
+// data is Viper's internal representation.
 var data = map[string]any{
 	"key": "value",
 	"list": []any{

--- a/internal/encoding/toml/codec_test.go
+++ b/internal/encoding/toml/codec_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// original form of the data
+// original form of the data.
 const original = `# key-value pair
 key = "value"
 list = ["item1", "item2", "item3"]
@@ -25,7 +25,7 @@ list = [
 ]
 `
 
-// encoded form of the data
+// encoded form of the data.
 const encoded = `key = 'value'
 list = ['item1', 'item2', 'item3']
 
@@ -38,7 +38,7 @@ key = 'value'
 list = ['item1', 'item2', 'item3']
 `
 
-// Viper's internal representation
+// data is Viper's internal representation.
 var data = map[string]any{
 	"key": "value",
 	"list": []any{

--- a/internal/encoding/yaml/codec_test.go
+++ b/internal/encoding/yaml/codec_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// original form of the data
+// original form of the data.
 const original = `# key-value pair
 key: value
 list:
@@ -26,7 +26,7 @@ nested_map:
             - item3
 `
 
-// encoded form of the data
+// encoded form of the data.
 const encoded = `key: value
 list:
     - item1
@@ -43,10 +43,10 @@ nested_map:
             - item3
 `
 
-// decoded form of the data
+// decoded form of the data.
 //
-// in case of YAML it's slightly different from Viper's internal representation
-// (eg. map is decoded into a map with interface key)
+// In case of YAML it's slightly different from Viper's internal representation
+// (e.g. map is decoded into a map with interface key).
 var decoded = map[string]any{
 	"key": "value",
 	"list": []any{
@@ -69,7 +69,7 @@ var decoded = map[string]any{
 	},
 }
 
-// Viper's internal representation
+// data is Viper's internal representation.
 var data = map[string]any{
 	"key": "value",
 	"list": []any{

--- a/overrides_test.go
+++ b/overrides_test.go
@@ -126,7 +126,7 @@ func overrideFromLayer(l layer, assert *assert.Assertions, firstPath string, fir
 }
 
 // deepCheckValue checks that all given keys correspond to a valid path in the
-// configuration map of the given layer, and that the final value equals the one given
+// configuration map of the given layer, and that the final value equals the one given.
 func deepCheckValue(assert *assert.Assertions, v *Viper, l layer, keys []string, value any) {
 	if assert == nil || v == nil ||
 		len(keys) == 0 || len(keys[0]) == 0 {

--- a/util.go
+++ b/util.go
@@ -156,7 +156,7 @@ func safeMul(a, b uint) uint {
 	return c
 }
 
-// parseSizeInBytes converts strings like 1GB or 12 mb into an unsigned integer number of bytes
+// parseSizeInBytes converts strings like 1GB or 12 mb into an unsigned integer number of bytes.
 func parseSizeInBytes(sizeStr string) uint {
 	sizeStr = strings.TrimSpace(sizeStr)
 	lastChar := len(sizeStr) - 1

--- a/viper.go
+++ b/viper.go
@@ -77,7 +77,7 @@ type remoteConfigFactory interface {
 	WatchChannel(rp RemoteProvider) (<-chan *RemoteResponse, chan bool)
 }
 
-// RemoteConfig is optional, see the remote package
+// RemoteConfig is optional, see the remote package.
 var RemoteConfig remoteConfigFactory
 
 // UnsupportedConfigError denotes encountering an unsupported
@@ -102,7 +102,7 @@ func (str UnsupportedRemoteProviderError) Error() string {
 // pull the configuration from the remote provider.
 type RemoteConfigError string
 
-// Error returns the formatted remote provider error
+// Error returns the formatted remote provider error.
 func (rce RemoteConfigError) Error() string {
 	return fmt.Sprintf("Remote Configurations Error: %s", string(rce))
 }
@@ -126,7 +126,7 @@ func (faee ConfigFileAlreadyExistsError) Error() string {
 }
 
 // A DecoderConfigOption can be passed to viper.Unmarshal to configure
-// mapstructure.DecoderConfig options
+// mapstructure.DecoderConfig options.
 type DecoderConfigOption func(*mapstructure.DecoderConfig)
 
 // DecodeHook returns a DecoderConfigOption which overrides the default
@@ -305,7 +305,7 @@ func Reset() {
 	SupportedRemoteProviders = []string{"etcd", "etcd3", "consul", "firestore", "nats"}
 }
 
-// TODO: make this lazy initialization instead
+// TODO: make this lazy initialization instead.
 func (v *Viper) resetEncoding() {
 	encoderRegistry := encoding.NewEncoderRegistry()
 	decoderRegistry := encoding.NewDecoderRegistry()
@@ -590,7 +590,7 @@ func (v *Viper) AddConfigPath(in string) {
 // path is the path in the k/v store to retrieve configuration
 // To retrieve a config file called myapp.json from /configs/myapp.json
 // you should set path to /configs and set config name (SetConfigName()) to
-// "myapp"
+// "myapp".
 func AddRemoteProvider(provider, endpoint, path string) error {
 	return v.AddRemoteProvider(provider, endpoint, path)
 }
@@ -622,8 +622,8 @@ func (v *Viper) AddRemoteProvider(provider, endpoint, path string) error {
 // path is the path in the k/v store to retrieve configuration
 // To retrieve a config file called myapp.json from /configs/myapp.json
 // you should set path to /configs and set config name (SetConfigName()) to
-// "myapp"
-// Secure Remote Providers are implemented with github.com/bketelsen/crypt
+// "myapp".
+// Secure Remote Providers are implemented with github.com/bketelsen/crypt.
 func AddSecureRemoteProvider(provider, endpoint, path, secretkeyring string) error {
 	return v.AddSecureRemoteProvider(provider, endpoint, path, secretkeyring)
 }
@@ -1115,7 +1115,7 @@ func (v *Viper) Unmarshal(rawVal any, opts ...DecoderConfigOption) error {
 }
 
 // defaultDecoderConfig returns default mapstructure.DecoderConfig with support
-// of time.Duration values & string slices
+// of time.Duration values & string slices.
 func defaultDecoderConfig(output any, opts ...DecoderConfigOption) *mapstructure.DecoderConfig {
 	c := &mapstructure.DecoderConfig{
 		Metadata:         nil,
@@ -1132,7 +1132,7 @@ func defaultDecoderConfig(output any, opts ...DecoderConfigOption) *mapstructure
 	return c
 }
 
-// A wrapper around mapstructure.Decode that mimics the WeakDecode functionality
+// decode is a wrapper around mapstructure.Decode that mimics the WeakDecode functionality.
 func decode(input any, config *mapstructure.DecoderConfig) error {
 	decoder, err := mapstructure.NewDecoder(config)
 	if err != nil {
@@ -1405,7 +1405,7 @@ func readAsCSV(val string) ([]string, error) {
 }
 
 // mostly copied from pflag's implementation of this operation here https://github.com/spf13/pflag/blob/master/string_to_string.go#L79
-// alterations are: errors are swallowed, map[string]any is returned in order to enable cast.ToStringMap
+// alterations are: errors are swallowed, map[string]any is returned in order to enable cast.ToStringMap.
 func stringToStringConv(val string) any {
 	val = strings.Trim(val, "[]")
 	// An empty string would cause an empty map
@@ -1429,7 +1429,7 @@ func stringToStringConv(val string) any {
 }
 
 // mostly copied from pflag's implementation of this operation here https://github.com/spf13/pflag/blob/d5e0c0615acee7028e1e2740a11102313be88de1/string_to_int.go#L68
-// alterations are: errors are swallowed, map[string]any is returned in order to enable cast.ToStringMap
+// alterations are: errors are swallowed, map[string]any is returned in order to enable cast.ToStringMap.
 func stringToIntConv(val string) any {
 	val = strings.Trim(val, "[]")
 	// An empty string would cause an empty map
@@ -2012,7 +2012,7 @@ func (v *Viper) watchRemoteConfig(provider RemoteProvider) (map[string]any, erro
 }
 
 // AllKeys returns all keys holding a value, regardless of where they are set.
-// Nested keys are returned with a v.keyDelim separator
+// Nested keys are returned with a v.keyDelim separator.
 func AllKeys() []string { return v.AllKeys() }
 
 func (v *Viper) AllKeys() []string {

--- a/viper_test.go
+++ b/viper_test.go
@@ -234,7 +234,7 @@ func initIni() {
 	unmarshalReader(r, v.config)
 }
 
-// make directories for testing
+// initDirs makes directories for testing.
 func initDirs(t *testing.T) (string, string) {
 	var (
 		testDirs = []string{`a a`, `b`, `C_`}
@@ -262,7 +262,7 @@ func initDirs(t *testing.T) (string, string) {
 	return root, config
 }
 
-// stubs for PFlag Values
+// stubs for PFlag Values.
 type stringValue string
 
 func newStringValue(val string, p *string) *stringValue {


### PR DESCRIPTION
This PR enables `godot` linter. `godot` ensures comments always end with a full stop. 