### PR TITLE
Add CaseSensitiveKeys option

### DIFF
--- a/util_test.go
+++ b/util_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCopyAndInsensitiviseMap(t *testing.T) {
+func TestCopyMap(t *testing.T) {
 	var (
 		given = map[string]any{
 			"Foo": 32,
@@ -35,19 +35,54 @@ func TestCopyAndInsensitiviseMap(t *testing.T) {
 				"cde": "B",
 			},
 		}
+		expectedPreserveCase = map[string]any{
+			"Foo": 32,
+			"Bar": map[string]any{
+				"ABc": "A",
+				"cDE": "B",
+			},
+		}
 	)
 
-	got := copyAndInsensitiviseMap(given)
+	t.Run("convert to lower-case", func(t *testing.T) {
+		got := CopyMap(given, false)
 
-	assert.Equal(t, expected, got)
-	_, ok := given["foo"]
-	assert.False(t, ok)
-	_, ok = given["bar"]
-	assert.False(t, ok)
+		assert.Equal(t, expected, got)
+		_, ok := given["foo"]
+		assert.False(t, ok)
+		_, ok = given["bar"]
+		assert.False(t, ok)
 
-	m := given["Bar"].(map[any]any)
-	_, ok = m["ABc"]
-	assert.True(t, ok)
+		m := given["Bar"].(map[any]any)
+		_, ok = m["ABc"]
+		assert.True(t, ok)
+	})
+
+	t.Run("preserve case", func(t *testing.T) {
+		got := CopyMap(given, true)
+
+		assert.Equal(t, expectedPreserveCase, got)
+		_, ok := given["foo"]
+		assert.False(t, ok)
+		_, ok = given["bar"]
+		assert.False(t, ok)
+
+		m := given["Bar"].(map[any]any)
+		_, ok = m["ABc"]
+		assert.True(t, ok)
+	})
+
+	t.Run("not a map", func(t *testing.T) {
+		var (
+			given    = []any{42, "xyz"}
+			expected = []any{42, "xyz"}
+		)
+		got := CopyMap(given, false)
+		assert.Equal(t, expected, got)
+
+		got = CopyMap(given, true)
+		assert.Equal(t, expected, got)
+	})
 }
 
 func TestAbsPathify(t *testing.T) {

--- a/viper_yaml_test.go
+++ b/viper_yaml_test.go
@@ -7,9 +7,9 @@ hobbies:
     - snowboarding
     - go
 clothing:
-    jacket: leather
+    Jacket: leather
     trousers: denim
-    pants:
+    Pants:
         size: large
 age: 35
 eyes : brown


### PR DESCRIPTION
Case-sensitive keys are one of the most request features of Viper.  See #1014.

When reading configuration from sources with case-sensitive keys, such as YAML, TOML, and JSON, a user may wish to preserve the case of keys that appear in maps.  For example, consider when the value of a setting is an (opaque) map with string keys that are case-sensitive. Ideally, if the map value is not going to be indexed by a Viper lookup key, then the map value should be treated as an opaque value by Viper, and its keys should not be modified.



Viper's default behavior is that keys are case-sensitive, and this behavior is implemented by converting all keys to lower-case.  For users that wish to preserve the case of keys, this commit introduces an Option `CaseSensitiveKeys()` that can be used to configure Viper to use case-sensitive keys.  When CaseSensitiveKeys is enabled, all keys retain the original case, and lookups become case-sensitive (except for lookups of values bound to environment variables).

The behavior of Viper could become hard to understand if a user could change the CaseSensitiveKeys setting after values have been stored.  For this reason, the setting may only be set when creating a Viper instance, and it cannot be set on the "global" Viper.  This merge request implements case-sensitive keys in a manner that respects the existing behavior of the "global" Viper, and gives users an option to create a Viper that uses case-sensitive keys behavior.