### PR TITLE
Sort keys before looping through them to avoid overwriting values

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -2138,6 +2139,7 @@ func (v *Viper) AllSettings() map[string]any {
 
 func (v *Viper) getSettings(keys []string) map[string]any {
 	m := map[string]any{}
+	sort.Strings(keys)
 	// start from the list of keys, and construct the map one value at a time
 	for _, k := range keys {
 		value := v.Get(k)


### PR DESCRIPTION
This is to fix the problem described in that issue: https://github.com/spf13/viper/issues/1717

The problem does not appear with go 1.17, but in go 1.21 yes. So while it won't fix anything for go1.17 and slowdown a bit the execution it will fix support for go 1.21. 

I used `sort.Strings` to make sure it is compatible with both go 1.17 and go 1.21. 