### PR TITLE
feat: make env variables accessible

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -2059,6 +2059,12 @@ func (v *Viper) watchRemoteConfig(provider RemoteProvider) (map[string]any, erro
 	return v.kvstore, err
 }
 
+func AllEnvVar() map[string][]string { return v.AllEnvVar() }
+
+func (v *Viper) AllEnvVar() map[string][]string {
+	return v.env
+}
+
 // AllKeys returns all keys holding a value, regardless of where they are set.
 // Nested keys are returned with a v.keyDelim separator.
 func AllKeys() []string { return v.AllKeys() }

--- a/viper_test.go
+++ b/viper_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/spf13/viper/internal/features"
 	"github.com/spf13/viper/internal/testutil"
@@ -652,6 +653,25 @@ func TestEmptyEnv_Allowed(t *testing.T) {
 
 	assert.Equal(t, "", Get("type"))
 	assert.Equal(t, "Cake", Get("name"))
+}
+
+func TestAllEnvVar(t *testing.T) {
+	initJSON()
+
+	SetEnvPrefix("foo") // will be uppercased automatically
+	BindEnv("id")
+	BindEnv("f", "FOOD", "BAR")
+
+	expectedEnvVariables := []byte(`f:
+    - FOO_FOOD
+    - FOO_BAR
+id:
+    - FOO_ID
+`)
+	yamlEnv, _ := yaml.Marshal(AllEnvVar())
+	assert.Equal(t, string(expectedEnvVariables), string(yamlEnv))
+
+	AutomaticEnv()
 }
 
 func TestEnvPrefix(t *testing.T) {


### PR DESCRIPTION
Make Env Variables publicly accessible.

I used this new function to include the environment variables automatically in the doc https://github.com/Bearer/bearer/pull/1446