### PR TITLE
Fix #1732 AutomaticEnv does not override Unmarshaled config slice values

### DIFF
--- a/viper_test.go
+++ b/viper_test.go
@@ -2611,6 +2611,10 @@ name: Steve
 port: 8080
 auth:
   secret: 88888-88888
+modes:
+  - 1
+  - 2
+  - 3
 clients:
   - name: foo
   - name: bar
@@ -2641,6 +2645,7 @@ func TestSliceIndexAutomaticEnv(t *testing.T) {
 		Port    int
 		Name    string
 		Auth    AuthConfig
+		Modes   []int
 		Clients []ClientConfig
 		Proxy   ProxyConfig
 	}
@@ -2655,10 +2660,12 @@ func TestSliceIndexAutomaticEnv(t *testing.T) {
 	assert.Equal(t, "foo", v.GetString("clients.0.name"))
 	assert.Equal(t, "bar", v.GetString("clients.1.name"))
 	assert.Equal(t, "proxy_foo", v.GetString("proxy.clients.0.name"))
+	assert.Equal(t, []int{1, 2, 3}, v.GetIntSlice("modes"))
 
 	// Override with env variable
 	t.Setenv("NAME", "Steven")
 	t.Setenv("AUTH_SECRET", "99999-99999")
+	t.Setenv("MODES_2", "300")
 	t.Setenv("CLIENTS_1_NAME", "baz")
 	t.Setenv("PROXY_CLIENTS_0_NAME", "ProxyFoo")
 
@@ -2672,6 +2679,7 @@ func TestSliceIndexAutomaticEnv(t *testing.T) {
 	assert.Equal(t, "Steven", config.Name)
 	assert.Equal(t, 8080, config.Port)
 	assert.Equal(t, "99999-99999", config.Auth.Secret)
+	assert.Equal(t, []int{1, 2, 300}, config.Modes)
 	assert.Equal(t, "foo", config.Clients[0].Name)
 	assert.Equal(t, "baz", config.Clients[1].Name)
 	assert.Equal(t, "ProxyFoo", config.Proxy.Clients[0].Name)

--- a/viper_test.go
+++ b/viper_test.go
@@ -2606,6 +2606,77 @@ func TestSliceIndexAccess(t *testing.T) {
 	assert.Equal(t, "Static", v.GetString("tv.0.episodes.1.2"))
 }
 
+var yamlSimpleSlice = []byte(`
+name: Steve
+port: 8080
+auth:
+  secret: 88888-88888
+clients:
+  - name: foo
+  - name: bar
+proxy:
+  clients:
+  - name: proxy_foo
+  - name: proxy_bar
+  - name: proxy_baz
+`)
+
+func TestSliceIndexAutomaticEnv(t *testing.T) {
+	v.SetConfigType("yaml")
+	r := strings.NewReader(string(yamlSimpleSlice))
+
+	type ClientConfig struct {
+		Name string
+	}
+
+	type AuthConfig struct {
+		Secret string
+	}
+
+	type ProxyConfig struct {
+		Clients []ClientConfig
+	}
+
+	type Configuration struct {
+		Port    int
+		Name    string
+		Auth    AuthConfig
+		Clients []ClientConfig
+		Proxy   ProxyConfig
+	}
+
+	// Read yaml as default value
+	err := v.unmarshalReader(r, v.config)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Steve", v.GetString("name"))
+	assert.Equal(t, 8080, v.GetInt("port"))
+	assert.Equal(t, "88888-88888", v.GetString("auth.secret"))
+	assert.Equal(t, "foo", v.GetString("clients.0.name"))
+	assert.Equal(t, "bar", v.GetString("clients.1.name"))
+	assert.Equal(t, "proxy_foo", v.GetString("proxy.clients.0.name"))
+
+	// Override with env variable
+	t.Setenv("NAME", "Steven")
+	t.Setenv("AUTH_SECRET", "99999-99999")
+	t.Setenv("CLIENTS_1_NAME", "baz")
+	t.Setenv("PROXY_CLIENTS_0_NAME", "ProxyFoo")
+
+	SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	AutomaticEnv()
+
+	// Unmarshal into struct
+	var config Configuration
+	v.Unmarshal(&config)
+
+	assert.Equal(t, "Steven", config.Name)
+	assert.Equal(t, 8080, config.Port)
+	assert.Equal(t, "99999-99999", config.Auth.Secret)
+	assert.Equal(t, "foo", config.Clients[0].Name)
+	assert.Equal(t, "baz", config.Clients[1].Name)
+	assert.Equal(t, "ProxyFoo", config.Proxy.Clients[0].Name)
+}
+
 func TestIsPathShadowedInFlatMap(t *testing.T) {
 	v := New()
 


### PR DESCRIPTION
fix #1732 

I have spent quite a lot of time trying to solve this. The difficulty lies in not knowing how many elements a slice config contains. The only option I see is to apply the `automatic env` override again after we `find` a key, since only then would we have retrieved all the slice fields, making it possible to check if the env for an individual slice element exists for overriding.

Please let me know if my changes are acceptable. I am happy to hear your feedback.
