### PR TITLE
fix: search config file error

### DIFF
--- a/file.go
+++ b/file.go
@@ -27,8 +27,9 @@ func (v *Viper) findConfigFile() (string, error) {
 func (v *Viper) searchInPath(in string) (filename string) {
 	v.logger.Debug("searching for config in path", "path", in)
 	if v.configType != "" {
-		if b, _ := exists(v.fs, filepath.Join(in, v.configName)); b {
-			return filepath.Join(in, v.configName)
+		if b, _ := exists(v.fs, filepath.Join(in, v.configName+"."+v.configType)); b {
+			v.logger.Debug("found file", "file", filepath.Join(in, v.configName+"."+v.configType))
+			return filepath.Join(in, v.configName+"."+v.configType)
 		}
 	}
 

--- a/file.go
+++ b/file.go
@@ -26,17 +26,17 @@ func (v *Viper) findConfigFile() (string, error) {
 
 func (v *Viper) searchInPath(in string) (filename string) {
 	v.logger.Debug("searching for config in path", "path", in)
+	if v.configType != "" {
+		if b, _ := exists(v.fs, filepath.Join(in, v.configName)); b {
+			return filepath.Join(in, v.configName)
+		}
+	}
+
 	for _, ext := range SupportedExts {
 		v.logger.Debug("checking if file exists", "file", filepath.Join(in, v.configName+"."+ext))
 		if b, _ := exists(v.fs, filepath.Join(in, v.configName+"."+ext)); b {
 			v.logger.Debug("found file", "file", filepath.Join(in, v.configName+"."+ext))
 			return filepath.Join(in, v.configName+"."+ext)
-		}
-	}
-
-	if v.configType != "" {
-		if b, _ := exists(v.fs, filepath.Join(in, v.configName)); b {
-			return filepath.Join(in, v.configName)
 		}
 	}
 


### PR DESCRIPTION
There have two config files that have same file name and different extention.
![image](https://github.com/spf13/viper/assets/62925104/b95aa8a5-fc87-4150-aba2-0c05c9288a78)
And their contents follow.
![image](https://github.com/spf13/viper/assets/62925104/ba3d920b-8239-4bfa-a884-01ae237a1bce)
![image](https://github.com/spf13/viper/assets/62925104/7934f86d-d73c-4b3a-9124-f1f0348ad9a1)
This is my code.That will produce a problem.I expect the file named "key_map.toml", but viper read the file named "key_map.json"
![image](https://github.com/spf13/viper/assets/62925104/b2e0472d-e7bb-469e-90a9-87adb63707b5)
 And that were some error information that viper gived.
![image](https://github.com/spf13/viper/assets/62925104/87bfbce3-92fc-497e-bc4a-27152fd1e4d1)
So I update the "file.go" to fix the problem.And now work good.
![image](https://github.com/spf13/viper/assets/62925104/49649ec9-f52f-4795-8531-da17a0b6518f)
