### PR TITLE
Update links to Golang Modules documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Many Go projects are built using Viper including:
 go get github.com/spf13/viper
 ```
 
-**Note:** Viper uses [Go Modules](https://github.com/golang/go/wiki/Modules) to manage dependencies.
+**Note:** Viper uses [Go Modules](https://go.dev/wiki/Modules) to manage dependencies.
 
 
 ## What is Viper?

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -15,10 +15,10 @@ cannot find package "github.com/hashicorp/hcl/tree/hcl1" in any of:
 ```
 
 As the error message suggests, Go tries to look up dependencies in `GOPATH` mode (as it's commonly called) from the `GOPATH`.
-Viper opted to use [Go Modules](https://github.com/golang/go/wiki/Modules) to manage its dependencies. While in many cases the two methods are interchangeable, once a dependency releases new (major) versions, `GOPATH` mode is no longer able to decide which version to use, so it'll either use one that's already present or pick a version (usually the `master` branch).
+Viper opted to use [Go Modules](https://go.dev/wiki/Modules) to manage its dependencies. While in many cases the two methods are interchangeable, once a dependency releases new (major) versions, `GOPATH` mode is no longer able to decide which version to use, so it'll either use one that's already present or pick a version (usually the `master` branch).
 
 The solution is easy: switch to using Go Modules.
-Please refer to the [wiki](https://github.com/golang/go/wiki/Modules) on how to do that.
+Please refer to the [wiki](https://go.dev/wiki/Modules) on how to do that.
 
 **tl;dr* `export GO111MODULE=on`
 


### PR DESCRIPTION
I noticed that the link to the Golang Modules documentation leads to a site that says

> The Go wiki on GitHub has moved to go.dev (#61940).

See: https://github.com/golang/go/wiki/Modules

This PR replaces the link in the README and TROUBLESHOOTING files with the one that's suggested on the old site.