### PR TITLE
fix: search file by supported extension use manually specific config …

### DIFF
--- a/file.go
+++ b/file.go
@@ -29,9 +29,22 @@ func (v *Viper) searchInPath(in string) (filename string) {
 	for _, ext := range SupportedExts {
 		v.logger.Debug("checking if file exists", "file", filepath.Join(in, v.configName+"."+ext))
 		if b, _ := exists(v.fs, filepath.Join(in, v.configName+"."+ext)); b {
-			v.logger.Debug("found file", "file", filepath.Join(in, v.configName+"."+ext))
-			return filepath.Join(in, v.configName+"."+ext)
+			// record the first found
+			if len(filename) < 1 {
+				filename = filepath.Join(in, v.configName+"."+ext)
+			}
+			// if specific configType are same with the current extension type, then return current
+			if v.configType == ext {
+				filename = filepath.Join(in, v.configName+"."+ext)
+				break
+			}
 		}
+	}
+
+	// return only if file exists
+	if len(filename) > 0 {
+		v.logger.Debug("found file", "file", filename)
+		return filename
 	}
 
 	if v.configType != "" {

--- a/file_test.go
+++ b/file_test.go
@@ -1,0 +1,142 @@
+package viper
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spf13/viper/internal/testutil"
+)
+
+func Test_searchInPath(t *testing.T) {
+	t.Run("find file without extension", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+
+		err := fs.Mkdir(testutil.AbsFilePath(t, "/etc/viper"), 0o777)
+		require.NoError(t, err)
+
+		file, err := fs.Create(testutil.AbsFilePath(t, "/etc/viper/config"))
+		require.NoError(t, err)
+
+		_, err = file.WriteString(`key: value`)
+		require.NoError(t, err)
+
+		file.Close()
+
+		v := New()
+
+		v.SetFs(fs)
+		v.AddConfigPath("/etc/viper")
+		v.SetConfigType("yaml")
+
+		err = v.ReadInConfig()
+		require.NoError(t, err)
+
+		assert.Equal(t, "value", v.Get("key"))
+	})
+
+	t.Run("cannot find file with extension", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+
+		err := fs.Mkdir(testutil.AbsFilePath(t, "/etc/viper"), 0o777)
+		require.NoError(t, err)
+
+		v := New()
+
+		v.SetFs(fs)
+		v.AddConfigPath("/etc/viper")
+		v.SetConfigType("yaml")
+
+		err = v.ReadInConfig()
+		require.EqualError(t, err, ConfigFileNotFoundError{v.configName, fmt.Sprintf("%s", v.configPaths)}.Error())
+	})
+
+	t.Run("find file with supported extension", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+
+		err := fs.Mkdir(testutil.AbsFilePath(t, "/etc/viper"), 0o777)
+		require.NoError(t, err)
+
+		file, err := fs.Create(testutil.AbsFilePath(t, "/etc/viper/config.yaml"))
+		require.NoError(t, err)
+
+		_, err = file.WriteString(`key: value`)
+		require.NoError(t, err)
+
+		file.Close()
+
+		v := New()
+
+		v.SetFs(fs)
+		v.AddConfigPath("/etc/viper")
+		v.SetConfigType("yaml")
+
+		err = v.ReadInConfig()
+		require.NoError(t, err)
+
+		assert.Equal(t, "value", v.Get("key"))
+	})
+
+	t.Run("find file with specific extension from multiple supported files", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+
+		err := fs.Mkdir(testutil.AbsFilePath(t, "/etc/viper"), 0o777)
+		require.NoError(t, err)
+
+		jsonFile, err := fs.Create(testutil.AbsFilePath(t, "/etc/viper/config.json"))
+		require.NoError(t, err)
+
+		jsonFile.Close()
+
+		file, err := fs.Create(testutil.AbsFilePath(t, "/etc/viper/config.yaml"))
+		require.NoError(t, err)
+
+		_, err = file.WriteString(`key: value`)
+		require.NoError(t, err)
+
+		file.Close()
+
+		v := New()
+
+		v.SetFs(fs)
+		v.AddConfigPath("/etc/viper")
+		v.SetConfigType("yaml")
+
+		err = v.ReadInConfig()
+		require.NoError(t, err)
+
+		assert.Equal(t, "value", v.Get("key"))
+	})
+
+	t.Run("find file with unsupported extension", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+
+		err := fs.Mkdir(testutil.AbsFilePath(t, "/etc/viper"), 0o777)
+		require.NoError(t, err)
+
+		jsonFile, err := fs.Create(testutil.AbsFilePath(t, "/etc/viper/config.json"))
+		require.NoError(t, err)
+
+		jsonFile.Close()
+
+		file, err := fs.Create(testutil.AbsFilePath(t, "/etc/viper/config.yaml"))
+		require.NoError(t, err)
+
+		_, err = file.WriteString(`key: value`)
+		require.NoError(t, err)
+
+		file.Close()
+
+		v := New()
+
+		v.SetFs(fs)
+		v.AddConfigPath("/etc/viper")
+		v.SetConfigType("xyz")
+
+		err = v.ReadInConfig()
+		require.EqualError(t, err, UnsupportedConfigError("xyz").Error())
+	})
+}


### PR DESCRIPTION
this PR is aimed to resolve issue #1754 and #1401, with compatible changes about `searchInPath`


test all imaginable situation passed and statement coverage is 100%:

```
=== RUN   Test_searchInPath
=== RUN   Test_searchInPath/find_file_without_extension
=== RUN   Test_searchInPath/cannot_find_file_with_extension
=== RUN   Test_searchInPath/find_file_with_supported_extension
=== RUN   Test_searchInPath/find_file_with_specific_extension_from_multiple_supported_files
=== RUN   Test_searchInPath/find_file_with_unsupported_extension
--- PASS: Test_searchInPath (0.00s)
    --- PASS: Test_searchInPath/find_file_without_extension (0.00s)
    --- PASS: Test_searchInPath/cannot_find_file_with_extension (0.00s)
    --- PASS: Test_searchInPath/find_file_with_supported_extension (0.00s)
    --- PASS: Test_searchInPath/find_file_with_specific_extension_from_multiple_supported_files (0.00s)
    --- PASS: Test_searchInPath/find_file_with_unsupported_extension (0.00s)
PASS
coverage: 17.1% of statements in ./...
```