### PR TITLE
New encoding layer

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -1,0 +1,113 @@
+package viper
+
+import (
+	"github.com/spf13/viper/internal/encoding/dotenv"
+	"github.com/spf13/viper/internal/encoding/hcl"
+	"github.com/spf13/viper/internal/encoding/ini"
+	"github.com/spf13/viper/internal/encoding/javaproperties"
+	"github.com/spf13/viper/internal/encoding/json"
+	"github.com/spf13/viper/internal/encoding/toml"
+	"github.com/spf13/viper/internal/encoding/yaml"
+)
+
+// Encoder encodes Viper's internal data structures into a byte representation.
+// It's primarily used for encoding a map[string]any into a file format.
+type Encoder interface {
+	Encode(v map[string]any) ([]byte, error)
+}
+
+// Decoder decodes the contents of a byte slice into Viper's internal data structures.
+// It's primarily used for decoding contents of a file into a map[string]any.
+type Decoder interface {
+	Decode(b []byte, v map[string]any) error
+}
+
+// Codec combines [Encoder] and [Decoder] interfaces.
+type Codec interface {
+	Encoder
+	Decoder
+}
+
+// EncoderRegistry returns an [Encoder] for a given format.
+// The second return value is false if no [Encoder] is registered for the format.
+type EncoderRegistry interface {
+	Encoder(format string) (Encoder, bool)
+}
+
+// DecoderRegistry returns an [Decoder] for a given format.
+// The second return value is false if no [Decoder] is registered for the format.
+type DecoderRegistry interface {
+	Decoder(format string) (Decoder, bool)
+}
+
+// [CodecRegistry] combines [EncoderRegistry] and [DecoderRegistry] interfaces.
+type CodecRegistry interface {
+	EncoderRegistry
+	DecoderRegistry
+}
+
+// WithEncoderRegistry sets a custom [EncoderRegistry].
+func WithEncoderRegistry(r EncoderRegistry) Option {
+	return optionFunc(func(v *Viper) {
+		v.encoderRegistry2 = r
+	})
+}
+
+// WithDecoderRegistry sets a custom [DecoderRegistry].
+func WithDecoderRegistry(r DecoderRegistry) Option {
+	return optionFunc(func(v *Viper) {
+		v.decoderRegistry2 = r
+	})
+}
+
+// WithCodecRegistry sets a custom [EncoderRegistry] and [DecoderRegistry].
+func WithCodecRegistry(r CodecRegistry) Option {
+	return optionFunc(func(v *Viper) {
+		v.encoderRegistry2 = r
+		v.decoderRegistry2 = r
+	})
+}
+
+type codecRegistry struct {
+	v *Viper
+}
+
+func (r codecRegistry) Encoder(format string) (Encoder, bool) {
+	return r.codec(format)
+}
+
+func (r codecRegistry) Decoder(format string) (Decoder, bool) {
+	return r.codec(format)
+}
+
+func (r codecRegistry) codec(format string) (Codec, bool) {
+	switch format {
+	case "yaml", "yml":
+		return yaml.Codec{}, true
+
+	case "json":
+		return json.Codec{}, true
+
+	case "toml":
+		return toml.Codec{}, true
+
+	case "hcl", "tfvars":
+		return hcl.Codec{}, true
+
+	case "ini":
+		return ini.Codec{
+			KeyDelimiter: r.v.keyDelim,
+			LoadOptions:  r.v.iniLoadOptions,
+		}, true
+
+	case "properties", "props", "prop": // Note: This breaks writing a properties file.
+		return &javaproperties.Codec{
+			KeyDelimiter: v.keyDelim,
+		}, true
+
+	case "dotenv", "env":
+		return &dotenv.Codec{}, true
+	}
+
+	return nil, false
+}

--- a/encoding.go
+++ b/encoding.go
@@ -61,22 +61,22 @@ type CodecRegistry interface {
 // WithEncoderRegistry sets a custom [EncoderRegistry].
 func WithEncoderRegistry(r EncoderRegistry) Option {
 	return optionFunc(func(v *Viper) {
-		v.encoderRegistry2 = r
+		v.encoderRegistry = r
 	})
 }
 
 // WithDecoderRegistry sets a custom [DecoderRegistry].
 func WithDecoderRegistry(r DecoderRegistry) Option {
 	return optionFunc(func(v *Viper) {
-		v.decoderRegistry2 = r
+		v.decoderRegistry = r
 	})
 }
 
 // WithCodecRegistry sets a custom [EncoderRegistry] and [DecoderRegistry].
 func WithCodecRegistry(r CodecRegistry) Option {
 	return optionFunc(func(v *Viper) {
-		v.encoderRegistry2 = r
-		v.decoderRegistry2 = r
+		v.encoderRegistry = r
+		v.decoderRegistry = r
 	})
 }
 
@@ -134,7 +134,7 @@ func (r codecRegistry) codec(format string) (Codec, bool) {
 	return nil, false
 }
 
-// DefaultCodecRegistry
+// DefaultCodecRegistry is a simple implementation of [CodecRegistry] that allows registering custom [Codec]s.
 type DefaultCodecRegistry struct {
 	codecs map[string]Codec
 
@@ -158,6 +158,8 @@ func (r *DefaultCodecRegistry) init() {
 }
 
 // RegisterCodec registers a custom [Codec].
+//
+// Format is case-insensitive.
 func (r *DefaultCodecRegistry) RegisterCodec(format string, codec Codec) error {
 	r.init()
 
@@ -169,6 +171,9 @@ func (r *DefaultCodecRegistry) RegisterCodec(format string, codec Codec) error {
 	return nil
 }
 
+// Encoder implements the [EncoderRegistry] interface.
+//
+// Format is case-insensitive.
 func (r *DefaultCodecRegistry) Encoder(format string) (Encoder, error) {
 	encoder, ok := r.codec(format)
 	if !ok {
@@ -178,6 +183,9 @@ func (r *DefaultCodecRegistry) Encoder(format string) (Encoder, error) {
 	return encoder, nil
 }
 
+// Decoder implements the [DecoderRegistry] interface.
+//
+// Format is case-insensitive.
 func (r *DefaultCodecRegistry) Decoder(format string) (Decoder, error) {
 	decoder, ok := r.codec(format)
 	if !ok {

--- a/encoding.go
+++ b/encoding.go
@@ -1,6 +1,7 @@
 package viper
 
 import (
+	"errors"
 	"strings"
 	"sync"
 
@@ -31,30 +32,18 @@ type Codec interface {
 	Decoder
 }
 
-type encodingError string
-
-func (e encodingError) Error() string {
-	return string(e)
-}
-
-const (
-	// ErrEncoderNotFound is returned when there is no encoder registered for a format.
-	ErrEncoderNotFound = encodingError("encoder not found for this format")
-
-	// ErrDecoderNotFound is returned when there is no decoder registered for a format.
-	ErrDecoderNotFound = encodingError("decoder not found for this format")
-)
+// TODO: consider adding specific errors for not found scenarios
 
 // EncoderRegistry returns an [Encoder] for a given format.
 //
-// The error is [ErrEncoderNotFound] if no [Encoder] is registered for the format.
+// [EncoderRegistry] returns an error if no [Encoder] is registered for the format.
 type EncoderRegistry interface {
 	Encoder(format string) (Encoder, error)
 }
 
 // DecoderRegistry returns an [Decoder] for a given format.
 //
-// The error is [ErrDecoderNotFound] if no [Decoder] is registered for the format.
+// [DecoderRegistry] returns an error if no [Decoder] is registered for the format.
 type DecoderRegistry interface {
 	Decoder(format string) (Decoder, error)
 }
@@ -94,7 +83,7 @@ type codecRegistry struct {
 func (r codecRegistry) Encoder(format string) (Encoder, error) {
 	encoder, ok := r.codec(format)
 	if !ok {
-		return nil, ErrEncoderNotFound
+		return nil, errors.New("encoder not found for this format")
 	}
 
 	return encoder, nil
@@ -103,7 +92,7 @@ func (r codecRegistry) Encoder(format string) (Encoder, error) {
 func (r codecRegistry) Decoder(format string) (Decoder, error) {
 	decoder, ok := r.codec(format)
 	if !ok {
-		return nil, ErrDecoderNotFound
+		return nil, errors.New("decoder not found for this format")
 	}
 
 	return decoder, nil
@@ -179,7 +168,7 @@ func (r *DefaultCodecRegistry) RegisterCodec(format string, codec Codec) error {
 func (r *DefaultCodecRegistry) Encoder(format string) (Encoder, error) {
 	encoder, ok := r.codec(format)
 	if !ok {
-		return nil, ErrEncoderNotFound
+		return nil, errors.New("encoder not found for this format")
 	}
 
 	return encoder, nil
@@ -188,7 +177,7 @@ func (r *DefaultCodecRegistry) Encoder(format string) (Encoder, error) {
 func (r *DefaultCodecRegistry) Decoder(format string) (Decoder, error) {
 	decoder, ok := r.codec(format)
 	if !ok {
-		return nil, ErrDecoderNotFound
+		return nil, errors.New("decoder not found for this format")
 	}
 
 	return decoder, nil

--- a/encoding.go
+++ b/encoding.go
@@ -36,12 +36,16 @@ type Codec interface {
 
 // EncoderRegistry returns an [Encoder] for a given format.
 //
+// Format is case-insensitive.
+//
 // [EncoderRegistry] returns an error if no [Encoder] is registered for the format.
 type EncoderRegistry interface {
 	Encoder(format string) (Encoder, error)
 }
 
 // DecoderRegistry returns an [Decoder] for a given format.
+//
+// Format is case-insensitive.
 //
 // [DecoderRegistry] returns an error if no [Decoder] is registered for the format.
 type DecoderRegistry interface {
@@ -99,7 +103,7 @@ func (r codecRegistry) Decoder(format string) (Decoder, error) {
 }
 
 func (r codecRegistry) codec(format string) (Codec, bool) {
-	switch format {
+	switch strings.ToLower(format) {
 	case "yaml", "yml":
 		return yaml.Codec{}, true
 
@@ -186,6 +190,8 @@ func (r *DefaultCodecRegistry) Decoder(format string) (Decoder, error) {
 func (r *DefaultCodecRegistry) codec(format string) (Codec, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	format = strings.ToLower(format)
 
 	if r.codecs != nil {
 		codec, ok := r.codecs[format]

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -36,4 +36,70 @@ func TestDefaultCodecRegistry(t *testing.T) {
 
 		assert.Equal(t, c, decoder)
 	})
+
+	t.Run("CodecNotFound", func(t *testing.T) {
+		registry := NewCodecRegistry()
+
+		_, err := registry.Encoder("myformat")
+		require.Error(t, err)
+
+		_, err = registry.Decoder("myformat")
+		require.Error(t, err)
+	})
+
+	t.Run("FormatIsCaseInsensitive", func(t *testing.T) {
+		registry := NewCodecRegistry()
+
+		c := codec{}
+
+		err := registry.RegisterCodec("MYFORMAT", c)
+		require.NoError(t, err)
+
+		{
+			encoder, err := registry.Encoder("myformat")
+			require.NoError(t, err)
+
+			assert.Equal(t, c, encoder)
+		}
+
+		{
+			encoder, err := registry.Encoder("MYFORMAT")
+			require.NoError(t, err)
+
+			assert.Equal(t, c, encoder)
+		}
+
+		{
+			decoder, err := registry.Decoder("myformat")
+			require.NoError(t, err)
+
+			assert.Equal(t, c, decoder)
+		}
+
+		{
+			decoder, err := registry.Decoder("MYFORMAT")
+			require.NoError(t, err)
+
+			assert.Equal(t, c, decoder)
+		}
+	})
+
+	t.Run("OverrideDefault", func(t *testing.T) {
+		registry := NewCodecRegistry()
+
+		c := codec{}
+
+		err := registry.RegisterCodec("yaml", c)
+		require.NoError(t, err)
+
+		encoder, err := registry.Encoder("yaml")
+		require.NoError(t, err)
+
+		assert.Equal(t, c, encoder)
+
+		decoder, err := registry.Decoder("yaml")
+		require.NoError(t, err)
+
+		assert.Equal(t, c, decoder)
+	})
 }

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -1,0 +1,39 @@
+package viper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type codec struct{}
+
+func (codec) Encode(_ map[string]any) ([]byte, error) {
+	return nil, nil
+}
+
+func (codec) Decode(_ []byte, _ map[string]any) error {
+	return nil
+}
+
+func TestDefaultCodecRegistry(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		registry := NewCodecRegistry()
+
+		c := codec{}
+
+		err := registry.RegisterCodec("myformat", c)
+		require.NoError(t, err)
+
+		encoder, err := registry.Encoder("myformat")
+		require.NoError(t, err)
+
+		assert.Equal(t, c, encoder)
+
+		decoder, err := registry.Decoder("myformat")
+		require.NoError(t, err)
+
+		assert.Equal(t, c, decoder)
+	})
+}

--- a/viper.go
+++ b/viper.go
@@ -1723,12 +1723,12 @@ func (v *Viper) unmarshalReader(in io.Reader, c map[string]any) error {
 
 	switch format := strings.ToLower(v.getConfigType()); format {
 	case "yaml", "yml", "json", "toml", "hcl", "tfvars", "ini", "properties", "props", "prop", "dotenv", "env":
-		decoder, ok := v.decoderRegistry2.Decoder(format)
-		if !ok {
-			return ConfigParseError{errors.New("decoder not found")}
+		decoder, err := v.decoderRegistry2.Decoder(format)
+		if err != nil {
+			return ConfigParseError{err}
 		}
 
-		err := decoder.Decode(buf.Bytes(), c)
+		err = decoder.Decode(buf.Bytes(), c)
 		if err != nil {
 			return ConfigParseError{err}
 		}
@@ -1743,10 +1743,9 @@ func (v *Viper) marshalWriter(f afero.File, configType string) error {
 	c := v.AllSettings()
 	switch configType {
 	case "yaml", "yml", "json", "toml", "hcl", "tfvars", "ini", "prop", "props", "properties", "dotenv", "env":
-		encoder, ok := v.encoderRegistry2.Encoder(configType)
-		if !ok {
-			// TODO: return a proper error
-			return ConfigMarshalError{errors.New("encoder not found")}
+		encoder, err := v.encoderRegistry2.Encoder(configType)
+		if err != nil {
+			return ConfigMarshalError{err}
 		}
 
 		b, err := encoder.Encode(c)

--- a/viper.go
+++ b/viper.go
@@ -184,8 +184,8 @@ type Viper struct {
 
 	logger *slog.Logger
 
-	encoderRegistry2 EncoderRegistry
-	decoderRegistry2 DecoderRegistry
+	encoderRegistry EncoderRegistry
+	decoderRegistry DecoderRegistry
 
 	experimentalFinder     bool
 	experimentalBindStruct bool
@@ -211,8 +211,8 @@ func New() *Viper {
 
 	codecRegistry := codecRegistry{v: v}
 
-	v.encoderRegistry2 = codecRegistry
-	v.decoderRegistry2 = codecRegistry
+	v.encoderRegistry = codecRegistry
+	v.decoderRegistry = codecRegistry
 
 	v.experimentalFinder = features.Finder
 	v.experimentalBindStruct = features.BindStruct
@@ -1623,7 +1623,7 @@ func (v *Viper) unmarshalReader(in io.Reader, c map[string]any) error {
 
 	switch format := strings.ToLower(v.getConfigType()); format {
 	case "yaml", "yml", "json", "toml", "hcl", "tfvars", "ini", "properties", "props", "prop", "dotenv", "env":
-		decoder, err := v.decoderRegistry2.Decoder(format)
+		decoder, err := v.decoderRegistry.Decoder(format)
 		if err != nil {
 			return ConfigParseError{err}
 		}
@@ -1643,7 +1643,7 @@ func (v *Viper) marshalWriter(f afero.File, configType string) error {
 	c := v.AllSettings()
 	switch configType {
 	case "yaml", "yml", "json", "toml", "hcl", "tfvars", "ini", "prop", "props", "properties", "dotenv", "env":
-		encoder, err := v.encoderRegistry2.Encoder(configType)
+		encoder, err := v.encoderRegistry.Encoder(configType)
 		if err != nil {
 			return ConfigMarshalError{err}
 		}

--- a/viper_test.go
+++ b/viper_test.go
@@ -1849,11 +1849,11 @@ var jsonWriteExpected = []byte(`{
   "type": "donut"
 }`)
 
-var propertiesWriteExpected = []byte(`p_id = 0001
-p_type = donut
+var propertiesWriteExpected = []byte(`p_batters.batter.type = Regular
+p_id = 0001
 p_name = Cake
 p_ppu = 0.55
-p_batters.batter.type = Regular
+p_type = donut
 `)
 
 // var yamlWriteExpected = []byte(`age: 35


### PR DESCRIPTION
Expose a new encoding abstraction layer. It allows users to bring their own encoding logic into Viper.

It also allows moving some of the less used formats (HCL, INI, Java properties) out of the core.