### PR TITLE
feat: copy keydelim from parent chart in viper.Sub()

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -773,6 +773,7 @@ func (v *Viper) Sub(key string) *Viper {
 		subv.automaticEnvApplied = v.automaticEnvApplied
 		subv.envPrefix = v.envPrefix
 		subv.envKeyReplacer = v.envKeyReplacer
+		subv.keyDelim = v.keyDelim
 		subv.config = cast.ToStringMap(data)
 		return subv
 	}

--- a/viper_test.go
+++ b/viper_test.go
@@ -1681,6 +1681,17 @@ func TestSub(t *testing.T) {
 	assert.Equal(t, []string{"clothing", "pants"}, subv.parents)
 }
 
+func TestSubWithKeyDelimiter(t *testing.T) {
+	v := NewWithOptions(KeyDelimiter("::"))
+	v.SetConfigType("yaml")
+	r := strings.NewReader(string(yamlExampleWithDot))
+	err := v.unmarshalReader(r, v.config)
+	require.NoError(t, err)
+
+	subv := v.Sub("emails")
+	assert.Equal(t, "01/02/03", subv.Get("steve@hacker.com::created"))
+}
+
 var jsonWriteExpected = []byte(`{
   "batters": {
     "batter": [


### PR DESCRIPTION
Addresses https://github.com/spf13/viper/issues/871

Simply copies the `keyDelim` from the parent chart to the subchart when calling `viper.Sub()`. Since there's currently no way to change the `keyDelim` of a viper instance post-creation, this is the only way to ensure that the `sub` viper instance maintains the `keyDelim`. 