### PR TITLE
docs: fix code snippet about to handle a missing configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ You can handle the specific case where no config file is found like this:
 
 ```go
 if err := viper.ReadInConfig(); err != nil {
-	if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+	var errNotFound viper.ConfigFileNotFoundError
+	if errors.As(err, &errNotFound) {
 		// Config file not found; ignore error if desired
 	} else {
 		// Config file was found but another error was produced


### PR DESCRIPTION
ConfigFileNotFoundError is a struct for 9 years ago (9fca1018)

The wrong information was added in the documentation 5 years ago (5ae3a072)
