### PR TITLE
fix(config): get config type from v.configType or config file ext

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1535,8 +1535,8 @@ func (v *Viper) MergeInConfig() error {
 func ReadConfig(in io.Reader) error { return v.ReadConfig(in) }
 
 func (v *Viper) ReadConfig(in io.Reader) error {
-	if v.configType == "" {
-		return errors.New("cannot decode configuration: config type is not set")
+	if v.getConfigType() == "" {
+		return errors.New("cannot decode configuration: unable to get config type from configType or file extension")
 	}
 
 	v.config = make(map[string]any)
@@ -1547,8 +1547,8 @@ func (v *Viper) ReadConfig(in io.Reader) error {
 func MergeConfig(in io.Reader) error { return v.MergeConfig(in) }
 
 func (v *Viper) MergeConfig(in io.Reader) error {
-	if v.configType == "" {
-		return errors.New("cannot decode configuration: config type is not set")
+	if v.getConfigType() == "" {
+		return errors.New("cannot decode configuration: unable to get config type from configType or file extension")
 	}
 
 	cfg := make(map[string]any)

--- a/viper_test.go
+++ b/viper_test.go
@@ -1542,6 +1542,14 @@ func TestReadConfig(t *testing.T) {
 	})
 }
 
+func TestReadConfigWithSetConfigFile(t *testing.T) {
+	v := New()
+	v.SetConfigFile("config.yaml") // Dummy value to infer config type from file extension
+	err := v.ReadConfig(bytes.NewBuffer(yamlMergeExampleSrc))
+	require.NoError(t, err)
+	assert.Equal(t, 45000, v.GetInt("hello.pop"))
+}
+
 func TestIsSet(t *testing.T) {
 	v := New()
 	v.SetConfigType("yaml")
@@ -2057,6 +2065,14 @@ func TestMergeConfig(t *testing.T) {
 	assert.Len(t, v.GetStringSlice("hello.universe"), 2)
 	assert.Len(t, v.GetIntSlice("hello.ints"), 2)
 	assert.Equal(t, "bar", v.GetString("fu"))
+}
+
+func TestMergeConfigWithSetConfigFile(t *testing.T) {
+	v := New()
+	v.SetConfigFile("config.yaml") // Dummy value to infer config type from file extension
+	err := v.MergeConfig(bytes.NewBuffer(yamlMergeExampleSrc))
+	require.NoError(t, err)
+	assert.Equal(t, 45000, v.GetInt("hello.pop"))
 }
 
 func TestMergeConfigOverrideType(t *testing.T) {


### PR DESCRIPTION
As described in the README, I expect viper to infer config type based on config file extension.
> viper.SetConfigType("yaml") // REQUIRED if the config file does not have the extension in the name

Since `1.20` this behavior seems broken.

If this is intended (or not working the way I think it should) let me know.

Fixes #1994 