### PR TITLE
Add support for flags pflag.BoolSlice, pflag.UintSlice and pflag.Float64Slice

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1181,11 +1181,26 @@ func (v *Viper) find(lcaseKey string, flagDefault bool) any {
 			s = strings.TrimSuffix(s, "]")
 			res, _ := readAsCSV(s)
 			return res
+		case "boolSlice":
+			s := strings.TrimPrefix(flag.ValueString(), "[")
+			s = strings.TrimSuffix(s, "]")
+			res, _ := readAsCSV(s)
+			return cast.ToBoolSlice(res)
 		case "intSlice":
 			s := strings.TrimPrefix(flag.ValueString(), "[")
 			s = strings.TrimSuffix(s, "]")
 			res, _ := readAsCSV(s)
 			return cast.ToIntSlice(res)
+		case "uintSlice":
+			s := strings.TrimPrefix(flag.ValueString(), "[")
+			s = strings.TrimSuffix(s, "]")
+			res, _ := readAsCSV(s)
+			return cast.ToUintSlice(res)
+		case "float64Slice":
+			s := strings.TrimPrefix(flag.ValueString(), "[")
+			s = strings.TrimSuffix(s, "]")
+			res, _ := readAsCSV(s)
+			return cast.ToFloat64Slice(res)
 		case "durationSlice":
 			s := strings.TrimPrefix(flag.ValueString(), "[")
 			s = strings.TrimSuffix(s, "]")
@@ -1268,11 +1283,26 @@ func (v *Viper) find(lcaseKey string, flagDefault bool) any {
 				s = strings.TrimSuffix(s, "]")
 				res, _ := readAsCSV(s)
 				return res
+			case "boolSlice":
+				s := strings.TrimPrefix(flag.ValueString(), "[")
+				s = strings.TrimSuffix(s, "]")
+				res, _ := readAsCSV(s)
+				return cast.ToBoolSlice(res)
 			case "intSlice":
 				s := strings.TrimPrefix(flag.ValueString(), "[")
 				s = strings.TrimSuffix(s, "]")
 				res, _ := readAsCSV(s)
 				return cast.ToIntSlice(res)
+			case "uintSlice":
+				s := strings.TrimPrefix(flag.ValueString(), "[")
+				s = strings.TrimSuffix(s, "]")
+				res, _ := readAsCSV(s)
+				return cast.ToUintSlice(res)
+			case "float64Slice":
+				s := strings.TrimPrefix(flag.ValueString(), "[")
+				s = strings.TrimSuffix(s, "]")
+				res, _ := readAsCSV(s)
+				return cast.ToFloat64Slice(res)
 			case "stringToString":
 				return stringToStringConv(flag.ValueString())
 			case "stringToInt":

--- a/viper_test.go
+++ b/viper_test.go
@@ -1210,6 +1210,29 @@ func TestBindPFlagsStringArray(t *testing.T) {
 	}
 }
 
+func TestBindPFlagsSlices(t *testing.T) {
+	set := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	set.IntSlice("intslice", []int{}, "")
+	set.BoolSlice("boolslice", []bool{}, "")
+	set.Float64Slice("float64slice", []float64{}, "")
+	set.UintSlice("uintslice", []uint{}, "")
+
+	v := New()
+	v.BindPFlags(set)
+
+	set.Set("intslice", "1,2")
+	assert.Equal(t, []int{1, 2}, v.Get("intslice"))
+
+	set.Set("boolslice", "true,false")
+	assert.Equal(t, []bool{true, false}, v.Get("boolslice"))
+
+	set.Set("float64slice", "1.1,2.2")
+	assert.Equal(t, []float64{1.1, 2.2}, v.Get("float64slice"))
+
+	set.Set("uintslice", "1,2")
+	assert.Equal(t, []uint{1, 2}, v.Get("uintslice"))
+}
+
 func TestSliceFlagsReturnCorrectType(t *testing.T) {
 	flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	flagSet.IntSlice("int", []int{1, 2}, "")


### PR DESCRIPTION
# Description 

This PR adds support for `pflag.BoolSlice`, `pflag.UintSlice` and `pflag.Float64Slice` (see failing test below).

Note: there are other pflag slices not supported, but this PR propose to add supports for at least one of each kind: Bool, Uint, & Float64.

# Extra Information

Below is a simple failing test

```golang
func TestBindPFlagsSlices(t *testing.T) {
	set := pflag.NewFlagSet("test", pflag.ContinueOnError)
        set.IntSlice("intslice", []int{}, "")
	set.BoolSlice("boolslice", []bool{}, "")
	set.Float64Slice("float64slice", []float64{}, "")
	set.UintSlice("uintslice", []uint{}, "")

	v := New()
	v.BindPFlags(set)

	// Does not fail as effectively supported
	set.Set("intslice", "1,2")
	assert.Equal(t, []int{1, 2}, v.Get("intslice"))

	// Fails as not supported
	set.Set("boolslice", "true,false")
	assert.Equal(t, []bool{true, false}, v.Get("boolslice"))

	// Fails as not supported
	set.Set("float64slice", "1.1,2.2")
	assert.Equal(t, []float64{1.1, 2.2}, v.Get("float64slice"))

	// Fails as not supported
	set.Set("uintslice", "1,2")
	assert.Equal(t, []uint{1, 2}, v.Get("uintslice"))
}
```