### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/util.go
+++ b/util.go
@@ -174,10 +174,7 @@ func parseSizeInBytes(sizeStr string) uint {
 		}
 	}
 
-	size := cast.ToInt(sizeStr)
-	if size < 0 {
-		size = 0
-	}
+	size := max(cast.ToInt(sizeStr), 0)
 
 	return safeMul(uint(size), multiplier)
 }


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.