### PR TITLE
chore: add a stale issue scheduled action

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,21 @@
+name: "Close stale issues"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      # Executes the stale issue action
+      # - Issues older than 30 days with no activity will receive a "Stale" label and a warning
+      # - Issues with a "Stale" label will close in 5 days
+      - uses: actions/stale@v9
+        with:
+          close-issue-message: "This issue has been closed for inactivity. Please re-open if this was a mistake."
+          days-before-close: 5
+          days-before-pr-stale: -1 # Ignore all PRs
+          days-before-stale: 30
+          debug-only: true # TODO for testing
+          stale-issue-message: "Issues with no activity for 30 days are marked stale and subject to being closed."
+
+on:
+  schedule:
+    - cron: "0 3 * * *"


### PR DESCRIPTION
This uses the [stale GHA](https://github.com/actions/stale) to schedule automatic stale marking and closure of issues.

As-is, this is marked in "debug" mode to see what it would be doing for us to verify before turning it on for real.

Open to ideas about how to test this, but it looks like it will only ever execute off of the default branch (per their docs).