### PR TITLE
feat: turn stale issue management on

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -17,5 +17,6 @@ jobs:
           days-before-pr-stale: -1 # Ignore all PRs
           stale-issue-message: "Issues with no activity for 30 days are marked stale and subject to being closed."
           close-issue-message: "This issue has been closed for inactivity. Please re-open if this was a mistake."
+          exempt-issue-labels: "lifecycle/keep"
           stale-issue-label: "lifecycle/stale"
           debug-only: false # Set this to 'true' to disable stale issue management


### PR DESCRIPTION
Looks like it's doing what it's supposed to and will start making issues as stale, somewhat conservatively, so I think we can turn it on: https://github.com/spf13/viper/actions/runs/17721172394/job/50353800256