### PR TITLE
Turn up the number of stale issue ops from 30 to 500

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -25,4 +25,5 @@ jobs:
           close-issue-message: "This issue has been closed for inactivity. Please re-open if this was a mistake."
           exempt-issue-labels: "lifecycle/keep"
           stale-issue-label: "lifecycle/stale"
+          operations-per-run: 500 # Must respect GitHub API limits
           debug-only: false # Set this to 'true' to disable stale issue management


### PR DESCRIPTION
Was curious why nothing was closing yet, I think this is why. This will take out a sizeable chunk of the daily allotted GitHub API calls, but will still be well below the ceiling (~4000).