### PR TITLE
fix: use RLock/RUnlock in codec() read method

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -151,8 +151,8 @@ func (r *DefaultCodecRegistry) Decoder(format string) (Decoder, error) {
 }
 
 func (r *DefaultCodecRegistry) codec(format string) (Codec, bool) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 
 	format = strings.ToLower(format)
 


### PR DESCRIPTION
Replace write lock with read lock in codec() to allow concurrent reads